### PR TITLE
feat(text): add TextAnalysis, Convergence, and HistoryCompressor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 group :development, :test do
   gem 'aigcm'
   gem 'amazing_print'
+  gem 'classifier', '~> 2.3'
   gem 'debug_me'
   gem 'hashdiff'
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.8)
+    addressable (2.8.9)
       public_suffix (>= 2.0.2, < 8.0)
     aigcm (0.3.2)
       ruby_llm
@@ -63,7 +63,7 @@ GEM
     anyway_config (2.8.0)
       ruby-next-core (~> 1.0)
     ast (2.4.3)
-    async (2.36.0)
+    async (2.38.1)
       console (~> 1.29)
       fiber-annotation
       io-event (~> 1.11)
@@ -80,7 +80,7 @@ GEM
       protocol-http2 (~> 0.22)
       protocol-url (~> 0.2)
       traces (~> 0.10)
-    async-pool (0.11.1)
+    async-pool (0.11.2)
       async (>= 2.0)
     async-websocket (0.30.0)
       async-http (~> 0.76)
@@ -90,6 +90,11 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.0.1)
     builder (3.3.0)
+    classifier (2.3.2)
+      fast-stemmer (~> 1.0)
+      matrix
+      mutex_m (~> 0.2)
+      rake
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     console (1.34.3)
@@ -120,6 +125,7 @@ GEM
       net-http (~> 0.5)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
+    fast-stemmer (1.0.2)
     fastembed (1.1.0)
       onnxruntime (~> 0.9)
       tokenizers (~> 0.5)
@@ -131,21 +137,21 @@ GEM
     fiber-storage (1.0.1)
     hana (1.3.7)
     hashdiff (1.2.1)
-    http-2 (1.1.2)
-    httpx (1.7.2)
-      http-2 (>= 1.0.0)
+    http-2 (1.1.3)
+    httpx (1.7.5)
+      http-2 (>= 1.1.3)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
     io-endpoint (0.17.2)
-    io-event (1.14.2)
+    io-event (1.14.4)
     io-stream (0.11.1)
     irb (1.17.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.18.1)
+    json (2.19.2)
     json-schema (5.1.0)
       addressable (~> 2.8)
     json_schemer (2.5.0)
@@ -156,10 +162,13 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.25.0)
+    loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     marcel (1.1.0)
+    matrix (0.4.3)
+    mcp (0.9.0)
+      json-schema (>= 4.1)
     metrics (0.15.0)
     minitest (6.0.2)
       drb (~> 2.0)
@@ -170,17 +179,18 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     multipart-post (2.4.1)
+    mutex_m (0.3.0)
     myway_config (0.1.2)
       anyway_config (>= 2.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    nokogiri (1.19.1-arm64-darwin)
+    nokogiri (1.19.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.1-x86_64-linux-gnu)
+    nokogiri (1.19.2-x86_64-linux-gnu)
       racc (~> 1.4)
-    onnxruntime (0.11.0-arm64-darwin)
+    onnxruntime (0.11.1-arm64-darwin)
       ffi
-    onnxruntime (0.11.0-x86_64-linux)
+    onnxruntime (0.11.1-x86_64-linux)
       ffi
     ostruct (0.6.3)
     parallel (1.27.0)
@@ -194,13 +204,13 @@ GEM
     prompt_manager (1.0.2)
       ostruct
     protocol-hpack (1.5.1)
-    protocol-http (0.59.0)
+    protocol-http (0.60.0)
     protocol-http1 (0.37.0)
       protocol-http (~> 0.58)
     protocol-http2 (0.24.0)
       protocol-hpack (~> 1.4)
       protocol-http (~> 0.47)
-    protocol-rack (0.21.1)
+    protocol-rack (0.22.0)
       io-stream (>= 0.10)
       protocol-http (~> 0.58)
       rack (>= 1.0)
@@ -210,7 +220,7 @@ GEM
     psych (5.3.1)
       date
       stringio
-    public_suffix (7.0.2)
+    public_suffix (7.0.5)
     racc (1.8.1)
     rack (3.2.5)
     rack-session (2.1.1)
@@ -246,10 +256,11 @@ GEM
     reline (0.6.3)
       io-console (~> 0.5)
     rexml (3.4.4)
-    rubocop (1.84.2)
+    rubocop (1.85.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
+      mcp (~> 0.6)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
@@ -257,18 +268,18 @@ GEM
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.0)
+    rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     ruby-next-core (1.2.0)
     ruby-progressbar (1.13.0)
-    ruby_llm (1.12.1)
+    ruby_llm (1.14.0)
       base64
       event_stream_parser (~> 1)
-      faraday (>= 2.0)
+      faraday (>= 1.10.0)
       faraday-multipart (>= 1)
       faraday-net_http (>= 1)
-      faraday-retry (>= 2.0)
+      faraday-retry (>= 1)
       marcel (~> 1)
       ruby_llm-schema (~> 0)
       zeitwerk (~> 2)
@@ -290,8 +301,8 @@ GEM
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     simpleidn (0.2.3)
-    sqlite3 (2.9.0-arm64-darwin)
-    sqlite3 (2.9.0-x86_64-linux-gnu)
+    sqlite3 (2.9.2-arm64-darwin)
+    sqlite3 (2.9.2-x86_64-linux-gnu)
     state_machines (0.100.4)
     state_machines-activemodel (0.101.0)
       activemodel (>= 7.2)
@@ -301,7 +312,7 @@ GEM
       state_machines-activemodel (>= 0.100.0)
     stringio (3.2.0)
     thor (1.5.0)
-    timeout (0.6.0)
+    timeout (0.6.1)
     tokenizers (0.6.3-arm64-darwin)
     tokenizers (0.6.3-x86_64-linux)
     traces (0.18.2)
@@ -316,7 +327,7 @@ GEM
     uri (1.1.1)
     useragent (0.16.11)
     vcr (6.4.0)
-    webmock (3.26.1)
+    webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -331,6 +342,7 @@ DEPENDENCIES
   activesupport (>= 7.0)
   aigcm
   amazing_print
+  classifier (~> 2.3)
   debug
   debug_me
   hashdiff
@@ -354,19 +366,20 @@ CHECKSUMS
   activemodel (8.1.2) sha256=e21358c11ce68aed3f9838b7e464977bc007b4446c6e4059781e1d5c03bcf33e
   activerecord (8.1.2) sha256=acfbe0cadfcc50fa208011fe6f4eb01cae682ebae0ef57145ba45380c74bcc44
   activesupport (8.1.2) sha256=88842578ccd0d40f658289b0e8c842acfe9af751afee2e0744a7873f50b6fdae
-  addressable (2.8.8) sha256=7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057
+  addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
   aigcm (0.3.2) sha256=eda5055a4bc1dd021f860b08134bf122f9df2e283da5be6719d1dde98a23428a
   amazing_print (2.0.0) sha256=2e36aba46ac78d37ed27ca0e2056afe3583183bb5c64f157c246b267355e5d6a
   ansi (1.5.0) sha256=5408253274e33d9d27d4a98c46d2998266fd51cba58a7eb9d08f50e57ed23592
   anyway_config (2.8.0) sha256=f6797a7231f81202dcd3d0c07284e836e45713e761d320180348b13a5c7c9306
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
-  async (2.36.0) sha256=090623f4c65706664355c9efa6c7bfb86771a513e65cd681c51cb27747530550
+  async (2.38.1) sha256=72ba6b7de04d852355458bfe891221226bb7d29f055f5cb043ae3345497f8cec
   async-http (0.94.2) sha256=c5ca94b337976578904a373833abe5b8dfb466a2946af75c4ae38c409c5c78b2
-  async-pool (0.11.1) sha256=98e1583e199a75f7dc70f8e65fc8d0d3b28636c3f256595d43e206642ad8fbda
+  async-pool (0.11.2) sha256=0a43a17b02b04d9c451b7d12fafa9a50e55dc6dd00d4369aca00433f16a7e3ed
   async-websocket (0.30.0) sha256=55739954528ad8f87f7792d0452e1268d1ef2aa5b3719f79400a05a1a6202cdf
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
+  classifier (2.3.2) sha256=f94c28e5d129a54939e6f828f18f8579a94dcf18b006df44e5790c9f15185620
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   console (1.34.3) sha256=869fbd74697efc4c606f102d2812b0b008e4e7fd738a91c591e8577140ec0dcc
@@ -384,6 +397,7 @@ CHECKSUMS
   faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
+  fast-stemmer (1.0.2) sha256=d0aa9fd9cfbca836a09d8abb122552ac8234130271a3b0da1cb077323d650819
   fastembed (1.1.0) sha256=0b59cd93cc6879bed599585404d3230103002b9fb966f1dfe0cc94c334ad168c
   ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f
   ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
@@ -392,32 +406,35 @@ CHECKSUMS
   fiber-storage (1.0.1) sha256=f48e5b6d8b0be96dac486332b55cee82240057065dc761c1ea692b2e719240e1
   hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
-  http-2 (1.1.2) sha256=8c1cb40203fc60b521c491509fee96c7b08092975eb30036465992433715ed40
-  httpx (1.7.2) sha256=10cdcd5b03794de743bec87e8cdba2ca93e2124084b6cdb1ad01b00c192a51f7
+  http-2 (1.1.3) sha256=1b2f379d35a11dbae94f8a1a52c053d8c161eb4a0c98b5d1605ff1b2bf171c9c
+  httpx (1.7.5) sha256=f002b7728ad108b721ab9c4e02b17b5c780581d490cd13245fc3d5c5b7127b6e
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   io-endpoint (0.17.2) sha256=3feaf766c116b35839c11fac68b6aaadc47887bb488902a57bf8e1d288fb3338
-  io-event (1.14.2) sha256=b0a069190eafe86005c22f7464f744971b5bd82f153740d34e6ab49548d4f613
+  io-event (1.14.4) sha256=455a9e4fb4613d12867b90461c297af6993b400a521bf62046f83b27f9c6aa3d
   io-stream (0.11.1) sha256=fa5f551fcff99581c1757b9d1cee2c37b124f07d2ca4f40b756a05ab9bd21b87
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
-  json (2.18.1) sha256=fe112755501b8d0466b5ada6cf50c8c3f41e897fa128ac5d263ec09eedc9f986
+  json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
   json-schema (5.1.0) sha256=c12729e346dce58ecc9be07301f4f247aeba1e3daae208e867278f3d27c64eb7
   json_schemer (2.5.0) sha256=2f01fb4cce721a4e08dd068fc2030cffd0702a7f333f1ea2be6e8991f00ae396
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  loofah (2.25.0) sha256=df5ed7ac3bac6a4ec802df3877ee5cc86d027299f8952e6243b3dac446b060e6
+  loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
+  matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
+  mcp (0.9.0) sha256=a0a3737b0ac9df0772f4ef7e2b013c260ddbcf217a5d50a66bff0baeddf03e47
   metrics (0.15.0) sha256=61ded5bac95118e995b1bc9ed4a5f19bc9814928a312a85b200abbdac9039072
   minitest (6.0.2) sha256=db6e57956f6ecc6134683b4c87467d6dd792323c7f0eea7b93f66bd284adbc3d
   minitest-reporters (1.7.1) sha256=5060413a0c95b8c32fe73e0606f3631c173a884d7900e50013e15094eb50562c
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
+  mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
   myway_config (0.1.2) sha256=c91741ded05babc443fcf5d012741ded8a1a1998c40a689cb32af27940b66be3
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
-  nokogiri (1.19.1-arm64-darwin) sha256=dfe2d337e6700eac47290407c289d56bcf85805d128c1b5a6434ddb79731cb9e
-  nokogiri (1.19.1-x86_64-linux-gnu) sha256=1a4902842a186b4f901078e692d12257678e6133858d0566152fe29cdb98456a
-  onnxruntime (0.11.0-arm64-darwin) sha256=8c52766a9c9e8c6e19f788d58322923ecd456094bd56e117759757925c464ae5
-  onnxruntime (0.11.0-x86_64-linux) sha256=eb10c9cef84298ed06d2471564192ef7074c6453c1899c179aea0753e0a8064e
+  nokogiri (1.19.2-arm64-darwin) sha256=58d8ea2e31a967b843b70487a44c14c8ba1866daa1b9da9be9dbdf1b43dee205
+  nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
+  onnxruntime (0.11.1-arm64-darwin) sha256=6d205e1adfcb77f0330b46ea9dcd3da9199034408dd5f58d56afca8e70fb686c
+  onnxruntime (0.11.1-x86_64-linux) sha256=90a47c9ab70103cdd4dd2b99b5179dfed909b44ceb77a1cf076e9dcff925079c
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.2) sha256=6f60c84aa4bdcedb6d1a2434b738fe8a8136807b6adc8f7f53b97da9bc4e9357
@@ -426,14 +443,14 @@ CHECKSUMS
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   prompt_manager (1.0.2) sha256=ec19631fc90d092df1d7d08aa3d523636f55a3725b90635afc1fae7d60609e31
   protocol-hpack (1.5.1) sha256=6feca238b8078da1cd295677d6f306c6001af92d75fe0643d33e6956cbc3ad91
-  protocol-http (0.59.0) sha256=90e20ad817cb3ffe947d4fd6194fe0651f385625dcce055386d1c356ee32547b
+  protocol-http (0.60.0) sha256=ca1354947676d663b6f23c49654aee464288774e7867c4a6e406fecce9691cec
   protocol-http1 (0.37.0) sha256=5bdd739e28792b341134596f6f5ab21a9d4b395f67bae69e153743eb0e69d123
   protocol-http2 (0.24.0) sha256=65327a019b7e36d2774e94050bf57a43bb60212775d2fcf02ae1d2ed4f01ef28
-  protocol-rack (0.21.1) sha256=366ff16efbf4c2f8d2e3fad4e992effa2357610f70effbccfa2767d26fedc577
+  protocol-rack (0.22.0) sha256=b7c49c0b597ca2c6d20f8bcd746c4415a1b750eacfbe64f828e780c978a4293d
   protocol-url (0.4.0) sha256=64d4c03b6b51ad815ac6fdaf77a1d91e5baf9220d26becb846c5459dacdea9e1
   protocol-websocket (0.20.2) sha256=c41d93c35fba5dae85375c597f76975f3dbd75d8c5b2f21b33dab4dc22a5a511
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
-  public_suffix (7.0.2) sha256=9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.5) sha256=4cbd0974c0b79f7a139b4812004a62e4c60b145cba76422e288ee670601ed6d3
   rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
@@ -449,11 +466,11 @@ CHECKSUMS
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   robot_lab (0.0.10)
-  rubocop (1.84.2) sha256=5692cea54168f3dc8cb79a6fe95c5424b7ea893c707ad7a4307b0585e88dbf5f
-  rubocop-ast (1.49.0) sha256=49c3676d3123a0923d333e20c6c2dbaaae2d2287b475273fddee0c61da9f71fd
+  rubocop (1.85.1) sha256=3dbcf9e961baa4c376eeeb2a03913dca5e3987033b04d38fa538aa1e7406cc77
+  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   ruby-next-core (1.2.0) sha256=f6a7d00bb5186cecbb02f7f1845a0f3a2c9788d35b6ccff5c9be3f0d46799b86
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
-  ruby_llm (1.12.1) sha256=154722483f2ab1c08d474eb696f56ed4ea046f8ac12fceb2c16a67f0a475c125
+  ruby_llm (1.14.0) sha256=57c6f7034fc4a44504ea137d70f853b07824f1c1cdbe774ab3ab3522e7098deb
   ruby_llm-mcp (1.0.0) sha256=9ec242b233c065cbad64f4f0508b711c9d39b83a4fdd0b1d3fc9d70dc95d82dc
   ruby_llm-schema (0.3.0) sha256=a591edc5ca1b7f0304f0e2261de61ba4b3bea17be09f5cf7558153adfda3dec6
   ruby_llm-semantic_cache (0.1.0) sha256=ad285968cfaed88cd8f5b9fc50ae64af815f3d4d6d862aa96d01c64a5f669815
@@ -463,14 +480,14 @@ CHECKSUMS
   simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
-  sqlite3 (2.9.0-arm64-darwin) sha256=a917bd9b84285766ff3300b7d79cd583f5a067594c8c1263e6441618c04a6ed3
-  sqlite3 (2.9.0-x86_64-linux-gnu) sha256=72fff9bd750070ba3af695511ba5f0e0a2d8a9206f84869640b3e99dfaf3d5a5
+  sqlite3 (2.9.2-arm64-darwin) sha256=d15bd9609a05f9d54930babe039585efc8cadd57517c15b64ec7dfa75158a5e9
+  sqlite3 (2.9.2-x86_64-linux-gnu) sha256=dce83ffcb7e72f9f7aeb6e5404f15d277a45332fe18ccce8a8b3ed51e8d23aee
   state_machines (0.100.4) sha256=dd4e555ebb061569dd8fe18a5f39b51d10be6306b89a0c315a9697671d752565
   state_machines-activemodel (0.101.0) sha256=6798c6bf5aa4be2b1a00ca633949c999ebee7a148bd4ea8f6858b189e2cdf72d
   state_machines-activerecord (0.100.0) sha256=b2213f74f3f32c6d92de5139e8898bc64a0ffb3f048df7d950ce27e28384beb5
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
-  timeout (0.6.0) sha256=6d722ad619f96ee383a0c557ec6eb8c4ecb08af3af62098a0be5057bf00de1af
+  timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
   tokenizers (0.6.3-arm64-darwin) sha256=29a6a5582dce106d846a906ee9e4254c12db45a3855c3ff6881d4be8be03e6b6
   tokenizers (0.6.3-x86_64-linux) sha256=77a45cbde59daac33bdda1a74d45c18080478992a00ee7d898e7b8d15d0b3149
   traces (0.18.2) sha256=80f1649cb4daace1d7174b81f3b3b7427af0b93047759ba349960cb8f315e214
@@ -482,7 +499,7 @@ CHECKSUMS
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   vcr (6.4.0) sha256=077ac92cc16efc5904eb90492a18153b5e6ca5398046d8a249a7c96a9ea24ae6
-  webmock (3.26.1) sha256=4f696fb57c90a827c20aadb2d4f9058bbff10f7f043bd0d4c3f58791143b1cd7
+  webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@
 - <strong>Rails Integration</strong> - Generators, background jobs, Turbo Stream broadcasting<br>
 - <strong>Token &amp; Cost Tracking</strong> - Per-run and cumulative token counts on every robot<br>
 - <strong>Tool Loop Circuit Breaker</strong> - <code>max_tool_rounds:</code> guards against runaway tool call loops<br>
-- <strong>Learning Accumulation</strong> - <code>robot.learn()</code> builds up cross-run observations with deduplication
+- <strong>Learning Accumulation</strong> - <code>robot.learn()</code> builds up cross-run observations with deduplication<br>
+- <strong>Context Window Compression</strong> - <code>robot.compress_history()</code> prunes irrelevant old turns via TF cosine scoring<br>
+- <strong>Convergence Detection</strong> - <code>RobotLab::Convergence</code> detects when independent agents agree, enabling reconciler fast-path
 </td>
 </tr>
 </table>

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -1,10 +1,12 @@
 # Observability & Safety
 
-Three facilities that help you monitor, control, and improve robot behaviour across runs:
+Facilities that help you monitor, control, improve, and scale robot behaviour:
 
 - **Token & Cost Tracking** — measure LLM usage per run and cumulatively
 - **Tool Loop Circuit Breaker** — guard against runaway tool call loops
 - **Learning Accumulation** — build up cross-run observations that guide future runs
+- **Context Window Compression** — prune irrelevant history to stay within token budgets
+- **Convergence Detection** — detect when independent agents reach the same conclusion
 
 ---
 
@@ -255,9 +257,146 @@ puts rebuilt.learnings.size  # same as original_robot.learnings.size
 
 ---
 
+## Context Window Compression
+
+### The Problem
+
+Long conversations accumulate turns that are no longer relevant to the current topic. Sending all of them to the LLM on every `run()` wastes tokens and money, and risks exceeding the model's context window.
+
+### robot.compress_history
+
+```ruby
+robot.compress_history(
+  recent_turns:    3,      # last N user+assistant pairs — always protected
+  keep_threshold:  0.6,    # score >= this → keep verbatim
+  drop_threshold:  0.2,    # score < this  → drop
+  summarizer:      nil     # optional lambda(text) -> String for medium tier
+)
+```
+
+Internally, each old turn is scored against the mean of the recent turns using stemmed term-frequency cosine similarity (via the `classifier` gem). Turns that score high are kept; turns that score low are dropped; turns in the middle band are either summarized or dropped depending on whether a `summarizer` is provided.
+
+**Always preserved regardless of score:**
+
+- System messages
+- Tool call/result message pairs
+- All messages within the `recent_turns` window
+
+### Thresholds
+
+```
+score >= keep_threshold   →  keep verbatim
+score <  drop_threshold   →  drop
+otherwise                 →  summarize (if summarizer given) or drop
+```
+
+A good starting point: `keep_threshold: 0.6, drop_threshold: 0.2`. Widen the drop band (raise `drop_threshold`) to compress more aggressively; raise `keep_threshold` to summarize more.
+
+### Without a Summarizer (Drop Mode)
+
+```ruby
+robot.compress_history(recent_turns: 3, keep_threshold: 0.6, drop_threshold: 0.2)
+```
+
+Medium-relevance turns are dropped along with low-relevance ones. This is the simplest form — no extra LLM calls, no added latency.
+
+### With an LLM Summarizer
+
+```ruby
+summarizer_bot = RobotLab.build(
+  name:          "summarizer",
+  system_prompt: "Summarize the following text in one sentence."
+)
+
+robot.compress_history(
+  recent_turns:    3,
+  keep_threshold:  0.6,
+  drop_threshold:  0.2,
+  summarizer:      ->(text) { summarizer_bot.run("Summarize: #{text}").reply }
+)
+```
+
+The summarizer replaces each medium-relevance turn with a one-sentence digest, preserving some context while reducing token count. The summary inherits the **original message's role** so the user/assistant alternation required by LLM APIs is maintained.
+
+### Optional Dependency
+
+`compress_history` requires the `classifier` gem. Add it to your Gemfile:
+
+```ruby
+gem "classifier", "~> 2.3"
+```
+
+Without it, calling `compress_history` raises `RobotLab::DependencyError` with an install hint.
+
+---
+
+## Convergence Detection
+
+### The Problem
+
+Multi-robot verification patterns (two independent reviewers, a debate network, a fact-checker) typically ask a reconciler robot to resolve any differences. But when both verifiers already agree, paying for that reconciler call is pure waste.
+
+### RobotLab::Convergence
+
+```ruby
+score = RobotLab::Convergence.similarity(text_a, text_b)  # Float 0.0..1.0
+agreed = RobotLab::Convergence.detected?(text_a, text_b)  # Boolean (threshold: 0.85)
+agreed = RobotLab::Convergence.detected?(text_a, text_b, threshold: 0.6)
+```
+
+Similarity is computed via L2-normalized stemmed term-frequency cosine similarity. Term frequencies (not TF-IDF) are used because fitting TF-IDF on a 2-document corpus suppresses shared terms to near-zero IDF, giving counter-intuitively low scores for texts that agree on the same topic.
+
+Texts shorter than 30 characters always return `0.0`.
+
+### Typical Scores
+
+| Relationship | Typical Score |
+|---|---|
+| Identical | 1.000 |
+| Same conclusion, different phrasing | 0.60 – 0.75 |
+| Same topic, different emphasis | 0.45 – 0.60 |
+| Unrelated | < 0.15 |
+
+### Router Fast-Path Pattern
+
+Skip the reconciler when verifiers agree:
+
+```ruby
+router = ->(args) do
+  a = args.context[:verifier_a]&.reply.to_s
+  b = args.context[:verifier_b]&.reply.to_s
+
+  if RobotLab::Convergence.detected?(a, b)
+    nil                  # both agree — network halts, no reconciler call
+  else
+    ["reconciler"]       # diverged — send to reconciler
+  end
+end
+
+network = RobotLab.create_network(
+  name:   "fact_check",
+  robots: [verifier_a, verifier_b, reconciler],
+  router: router
+)
+```
+
+Tune `threshold:` to control how strictly "agreement" is defined. A lower threshold (e.g., `0.6`) accepts more variation between verifiers; a higher threshold (e.g., `0.9`) only fast-paths near-identical responses.
+
+### Optional Dependency
+
+`RobotLab::Convergence` requires the `classifier` gem (same as `compress_history`):
+
+```ruby
+gem "classifier", "~> 2.3"
+```
+
+---
+
 ## See Also
 
 - [Robot API](../api/core/robot.md#token--cost-tracking)
 - [Example 19 — Token & Cost Tracking](../../examples/19_token_tracking.rb)
 - [Example 20 — Tool Loop Circuit Breaker](../../examples/20_circuit_breaker.rb)
 - [Example 21 — Learning Accumulation Loop](../../examples/21_learning_loop.rb)
+- [Example 22 — Context Window Compression](../../examples/22_context_compression.rb)
+- [Example 23 — Convergence Detection](../../examples/23_convergence.rb)

--- a/examples/22_context_compression.rb
+++ b/examples/22_context_compression.rb
@@ -1,0 +1,179 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Example 22: Context Window Compression
+#
+# Demonstrates robot.compress_history() for reducing token usage in long
+# conversations. Old turns are scored against the recent context using
+# stemmed term-frequency cosine similarity. High-relevance turns are kept
+# verbatim; irrelevant turns are dropped; medium-relevance turns can be
+# summarized by a second robot.
+#
+# Demonstrates:
+#   - robot.compress_history() — drop/keep/summarize old turns in-place
+#   - recent_turns: N — last N user+assistant pairs always protected
+#   - keep_threshold: / drop_threshold: — tunable relevance bands
+#   - summarizer: — optional lambda(text) -> String for medium-relevance
+#   - Token reduction reported before/after compression
+#
+# Requires:
+#   gem 'classifier', '~> 2.3'   # add to your Gemfile
+#
+# Usage:
+#   ANTHROPIC_API_KEY=your_key ruby examples/22_context_compression.rb
+
+ENV["ROBOT_LAB_TEMPLATE_PATH"] ||= File.join(__dir__, "prompts")
+
+require_relative "../lib/robot_lab"
+
+# ---------------------------------------------------------------------------
+# Check optional dependency
+# ---------------------------------------------------------------------------
+begin
+  require "classifier"
+rescue LoadError
+  puts "This example requires the classifier gem."
+  puts "Add to your Gemfile:  gem 'classifier', '~> 2.3'"
+  exit 1
+end
+
+# ---------------------------------------------------------------------------
+# Helper to count approximate tokens (rough: 4 chars per token)
+# ---------------------------------------------------------------------------
+def approx_tokens(messages)
+  messages.sum do |m|
+    content = m.respond_to?(:content) ? m.content.to_s : m.to_s
+    (content.length / 4.0).ceil
+  end
+end
+
+puts "=" * 60
+puts "Example 22: Context Window Compression"
+puts "=" * 60
+puts
+
+# ---------------------------------------------------------------------------
+# Build a robot and simulate a long conversation on two topics
+# ---------------------------------------------------------------------------
+bot = RobotLab.build(
+  name:          "assistant",
+  system_prompt: "You are a concise Ruby expert. Reply in 2-3 sentences."
+)
+
+puts "Simulating a long conversation (no real LLM calls)..."
+puts
+
+# Simulate a conversation history with two distinct topics:
+# older turns: Ruby metaprogramming (will become irrelevant)
+# recent turns: Rails routing (current topic)
+
+require "ostruct"
+
+FakeMsg = Struct.new(:role, :content, :tool_calls, :stop_reason) do
+  def text?      = true
+  def tool_use?  = false
+  def system?    = role == :system
+  def user?      = role == :user
+  def assistant? = role == :assistant
+end
+
+def fake(role, content)
+  FakeMsg.new(role.to_sym, content, nil, :stop)
+end
+
+history = [
+  fake(:system,    "You are a concise Ruby expert. Reply in 2-3 sentences."),
+
+  # --- OLD TOPIC: Ruby metaprogramming (5 turns back) ---
+  fake(:user,      "Explain Ruby's method_missing and when to use it."),
+  fake(:assistant, "method_missing is called when an object receives an undefined message. It's useful for DSLs and proxy objects, but add respond_to_missing? too. Use sparingly as it hurts performance."),
+  fake(:user,      "What's the difference between define_method and def?"),
+  fake(:assistant, "define_method creates methods dynamically from a block, capturing closure variables. def is the static keyword form. Use define_method when the method body depends on runtime values."),
+  fake(:user,      "How does BasicObject differ from Object in Ruby?"),
+  fake(:assistant, "BasicObject is the root class with minimal methods, useful for proxy and DSL objects that must not inherit standard methods. Object inherits from BasicObject and adds Kernel, making it the normal base class."),
+
+  # --- RECENT TOPIC: Rails routing (last 2 turns, always protected) ---
+  fake(:user,      "How does Rails routing work with resourceful controllers?"),
+  fake(:assistant, "resources :posts generates 7 RESTful routes mapping HTTP verbs to controller actions. You can nest resources and add member/collection routes. Run rails routes to see everything."),
+  fake(:user,      "What is the difference between member and collection routes in Rails?"),
+  fake(:assistant, "Member routes operate on a specific resource (needs :id), collection routes operate on the whole collection. Use member { get :preview } and collection { get :search } inside a resources block.")
+]
+
+before_count = history.size
+before_tokens = approx_tokens(history)
+
+puts "Before compression:"
+puts "  Messages : #{before_count}"
+puts "  ~Tokens  : #{before_tokens}"
+puts
+
+# ---------------------------------------------------------------------------
+# Option A: Drop medium-relevance turns (no summarizer)
+# ---------------------------------------------------------------------------
+compressor_a = RobotLab::HistoryCompressor.new(
+  messages:        history,
+  recent_turns:    2,
+  keep_threshold:  0.25,
+  drop_threshold:  0.05,
+  summarizer:      nil
+)
+
+result_a = compressor_a.call
+tokens_a = approx_tokens(result_a)
+
+puts "After compression (drop mode, recent_turns: 2, keep: 0.25, drop: 0.05):"
+puts "  Messages : #{result_a.size}  (removed #{before_count - result_a.size})"
+puts "  ~Tokens  : #{tokens_a}  (saved #{before_tokens - tokens_a})"
+puts "  Kept roles: #{result_a.map(&:role).join(', ')}"
+puts
+
+# ---------------------------------------------------------------------------
+# Option B: With a summarizer lambda for medium-relevance turns
+# ---------------------------------------------------------------------------
+puts "After compression (summarize mode, keep: 0.5, drop: 0.05):"
+
+summarizer = lambda do |text|
+  # In production this would call a small LLM robot.
+  # Here we fake it by taking the first sentence.
+  text.split(/[.!?]/).first.to_s.strip + "."
+end
+
+compressor_b = RobotLab::HistoryCompressor.new(
+  messages:        history,
+  recent_turns:    2,
+  keep_threshold:  0.5,
+  drop_threshold:  0.05,
+  summarizer:      summarizer
+)
+
+result_b = compressor_b.call
+tokens_b = approx_tokens(result_b)
+
+puts "  Messages : #{result_b.size}  (removed #{before_count - result_b.size})"
+puts "  ~Tokens  : #{tokens_b}  (saved #{before_tokens - tokens_b})"
+puts "  Kept roles: #{result_b.map(&:role).join(', ')}"
+puts
+
+# ---------------------------------------------------------------------------
+# Show the LLM summarizer pattern (not executed — requires API key)
+# ---------------------------------------------------------------------------
+puts "=" * 60
+puts "LLM summarizer pattern (requires API key):"
+puts "=" * 60
+puts <<~RUBY
+
+  summarizer_bot = RobotLab.build(
+    name:          "summarizer",
+    system_prompt: "Summarize the following text in one sentence."
+  )
+
+  robot.compress_history(
+    recent_turns:    3,
+    keep_threshold:  0.6,
+    drop_threshold:  0.2,
+    summarizer:      ->(text) { summarizer_bot.run("Summarize: \#{text}").reply }
+  )
+
+RUBY
+
+puts "Done."

--- a/examples/23_convergence.rb
+++ b/examples/23_convergence.rb
@@ -1,0 +1,137 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Example 23: Debate Convergence Detection
+#
+# Demonstrates RobotLab::Convergence for detecting when two independent
+# agents have reached the same conclusion. This enables a fast-path that
+# skips an expensive reconciler LLM call when verifiers already agree.
+#
+# Demonstrates:
+#   - Convergence.similarity(a, b) — 0.0..1.0 cosine similarity score
+#   - Convergence.detected?(a, b) — boolean above default threshold (0.85)
+#   - Convergence.detected?(a, b, threshold: 0.6) — custom threshold
+#   - Router fast-path pattern: skip reconciler when verifiers agree
+#
+# Requires:
+#   gem 'classifier', '~> 2.3'   # add to your Gemfile
+#
+# Usage:
+#   ANTHROPIC_API_KEY=your_key ruby examples/23_convergence.rb
+
+ENV["ROBOT_LAB_TEMPLATE_PATH"] ||= File.join(__dir__, "prompts")
+
+require_relative "../lib/robot_lab"
+
+# ---------------------------------------------------------------------------
+# Check optional dependency
+# ---------------------------------------------------------------------------
+begin
+  require "classifier"
+rescue LoadError
+  puts "This example requires the classifier gem."
+  puts "Add to your Gemfile:  gem 'classifier', '~> 2.3'"
+  exit 1
+end
+
+puts "=" * 60
+puts "Example 23: Debate Convergence Detection"
+puts "=" * 60
+puts
+
+# ---------------------------------------------------------------------------
+# Similarity scoring
+# ---------------------------------------------------------------------------
+pairs = {
+  "Identical responses" => [
+    "The time complexity of quicksort is O(n log n) average case and O(n²) worst case. Use merge sort for guaranteed O(n log n).",
+    "The time complexity of quicksort is O(n log n) average case and O(n²) worst case. Use merge sort for guaranteed O(n log n)."
+  ],
+  "Semantically similar (same conclusion)" => [
+    "Quicksort has average O(n log n) time complexity but degrades to O(n²) in the worst case. Prefer merge sort when stability matters.",
+    "The average time complexity of quicksort is O(n log n). In the worst case it becomes O(n²), so merge sort is safer for sorted input."
+  ],
+  "Partially related (same topic, different focus)" => [
+    "Quicksort is O(n log n) average case. It is in-place and cache-friendly, making it fast in practice despite worst-case concerns.",
+    "Merge sort guarantees O(n log n) in all cases and is stable. It requires O(n) extra space unlike the in-place quicksort."
+  ],
+  "Unrelated responses" => [
+    "Quicksort has average O(n log n) time complexity but degrades to O(n²) in the worst case.",
+    "The Pacific Ocean is the largest and deepest ocean on Earth, covering more than thirty percent of the planet surface area."
+  ]
+}
+
+puts "Similarity scores:"
+puts "-" * 60
+pairs.each do |label, (a, b)|
+  score = RobotLab::Convergence.similarity(a, b)
+  converged = RobotLab::Convergence.detected?(a, b, threshold: 0.6)
+  puts "  #{label}"
+  puts "    Score: #{"%.3f" % score}  |  Converged at 0.60: #{converged ? "YES" : "no"}"
+  puts
+end
+
+# ---------------------------------------------------------------------------
+# Router fast-path pattern
+# ---------------------------------------------------------------------------
+puts "=" * 60
+puts "Router fast-path pattern"
+puts "=" * 60
+puts <<~RUBY
+
+  # Two verifier robots run in parallel and store their replies in shared memory.
+  # The router checks convergence before dispatching to the expensive reconciler.
+
+  router = ->(args) do
+    a = args.context[:verifier_a]&.reply.to_s
+    b = args.context[:verifier_b]&.reply.to_s
+
+    if RobotLab::Convergence.detected?(a, b)
+      nil   # Both agree — skip reconciler, network halts here
+    else
+      ["reconciler"]
+    end
+  end
+
+  network = RobotLab.create_network(
+    name:   "fact_check",
+    robots: [verifier_a, verifier_b, reconciler],
+    router: router
+  )
+
+  result = network.run(message: "Is this claim accurate?")
+
+RUBY
+
+# ---------------------------------------------------------------------------
+# Demonstrate with simulated verifier outputs
+# ---------------------------------------------------------------------------
+puts "Simulating verifier fast-path:"
+puts "-" * 60
+
+verifier_outputs = [
+  {
+    label:  "Verifiers agree (skip reconciler)",
+    a:      "The claim is accurate. Photosynthesis converts light energy into glucose using carbon dioxide and water, producing oxygen as a byproduct.",
+    b:      "This is correct. Photosynthesis uses sunlight, CO₂, and water to produce glucose and oxygen in plant cells.",
+    threshold: 0.5
+  },
+  {
+    label:  "Verifiers disagree (call reconciler)",
+    a:      "The claim is accurate. The Great Wall of China is visible from space with the naked eye at low Earth orbit.",
+    b:      "The claim is false. Astronauts confirm the Great Wall cannot be seen from space without magnification because it is far too narrow.",
+    threshold: 0.7
+  }
+]
+
+verifier_outputs.each do |scenario|
+  score     = RobotLab::Convergence.similarity(scenario[:a], scenario[:b])
+  converged = RobotLab::Convergence.detected?(scenario[:a], scenario[:b], threshold: scenario[:threshold])
+  action    = converged ? "SKIP reconciler (fast-path)" : "CALL reconciler"
+
+  puts "  #{scenario[:label]}"
+  puts "    Score: #{"%.3f" % score}  →  #{action}"
+  puts
+end
+
+puts "Done."

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,6 +48,8 @@ examples/
   19_token_tracking.rb        # Per-robot token & cost tracking
   20_circuit_breaker.rb       # Tool loop circuit breaker with max_tool_rounds
   21_learning_loop.rb         # Learning accumulation across runs with robot.learn
+  22_context_compression.rb   # Context window compression with HistoryCompressor
+  23_convergence.rb           # Debate convergence detection and reconciler fast-path
   18_rails/                   # Minimal Rails 8 demo app (full integration)
     app/robots/chat_robot.rb  #   Robot factory with system prompt + TimeTool
     app/tools/time_tool.rb    #   Custom RobotLab::Tool subclass
@@ -181,6 +183,18 @@ Guards against runaway tool call loops using `max_tool_rounds:`. A step processo
 Builds up cross-run observations with `robot.learn(text)`. A code reviewer accumulates one key insight after each review. On subsequent runs, learnings are automatically prepended to the user message as a "LEARNINGS FROM PREVIOUS RUNS:" block. Demonstrates bidirectional substring deduplication (broader learnings replace narrower ones), the `robot.learnings` accessor, and how learnings survive a robot rebuild via the shared `Memory` object.
 
 **Requires:** LLM API key
+
+### 22 — Context Window Compression
+
+Demonstrates `robot.compress_history()` for reducing token usage in long conversations. Old turns are scored against the recent context using stemmed term-frequency cosine similarity (via the `classifier` gem). High-relevance turns are kept verbatim; irrelevant turns are dropped; medium-relevance turns can optionally be summarized by a second robot. Shows both drop-mode and summarizer-lambda patterns, plus the LLM summarizer integration recipe.
+
+**Requires:** `gem 'classifier', '~> 2.3'` in your Gemfile (no LLM calls in the demo itself)
+
+### 23 — Debate Convergence Detection
+
+Demonstrates `RobotLab::Convergence` for detecting when two independent agents have reached the same conclusion. Scores pairs of texts from identical → semantically similar → partially related → unrelated, showing how the similarity metric varies. Includes the router fast-path pattern: when two verifier robots agree above a threshold, the expensive reconciler LLM call is skipped entirely.
+
+**Requires:** `gem 'classifier', '~> 2.3'` in your Gemfile (no LLM calls in the demo itself)
 
 ### 18 — Rails Integration Demo
 

--- a/lib/robot_lab/convergence.rb
+++ b/lib/robot_lab/convergence.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module RobotLab
+  # TF-IDF cosine similarity utilities for detecting semantic convergence
+  # between two texts.
+  #
+  # Common use cases:
+  # - Checking whether two independent verifiers have reached the same conclusion
+  # - Skipping a reconciler LLM call when verifiers already agree (fast-path)
+  # - Detecting when a multi-robot debate has converged on a consensus
+  #
+  # Requires the optional 'classifier' gem (~> 2.3).
+  #
+  # @example Skip reconciler when verifiers agree
+  #   score = RobotLab::Convergence.similarity(result_a.reply, result_b.reply)
+  #
+  #   router = ->(args) do
+  #     a = args.context[:verifier_a]&.reply.to_s
+  #     b = args.context[:verifier_b]&.reply.to_s
+  #     RobotLab::Convergence.detected?(a, b) ? nil : ["reconciler"]
+  #   end
+  module Convergence
+    # Default cosine similarity threshold above which texts are convergent.
+    DEFAULT_THRESHOLD = 0.85
+
+    # Minimum text length (characters) for meaningful TF-IDF scoring.
+    # Texts shorter than this always return 0.0 similarity.
+    MIN_TEXT_LENGTH = 30
+
+    # Determine whether two texts are semantically convergent.
+    #
+    # @param text_a [String]
+    # @param text_b [String]
+    # @param threshold [Float] minimum similarity to declare convergence (default 0.85)
+    # @return [Boolean]
+    # @raise [DependencyError] if the 'classifier' gem is not installed
+    # @raise [ArgumentError] if threshold is outside [0.0, 1.0]
+    def self.detected?(text_a, text_b, threshold: DEFAULT_THRESHOLD)
+      unless (0.0..1.0).cover?(threshold)
+        raise ArgumentError, "threshold must be in [0.0, 1.0], got #{threshold}"
+      end
+
+      similarity(text_a, text_b) >= threshold
+    end
+
+    # Compute cosine similarity between two texts using stemmed term frequencies.
+    #
+    # Uses +String#word_hash+ (provided by the classifier gem) to build
+    # stemmed, stopword-filtered term-frequency vectors, then computes
+    # L2-normalized cosine similarity. Term frequencies (no IDF) are used
+    # because IDF on a 2-document corpus collapses shared terms to zero,
+    # which would incorrectly penalize texts that agree on the same topic.
+    #
+    # Returns 0.0 when either text is blank or shorter than +MIN_TEXT_LENGTH+.
+    #
+    # @param text_a [String]
+    # @param text_b [String]
+    # @return [Float] in [0.0, 1.0]
+    # @raise [DependencyError] if the 'classifier' gem is not installed
+    def self.similarity(text_a, text_b)
+      a = text_a.to_s.strip
+      b = text_b.to_s.strip
+
+      return 0.0 if a.length < MIN_TEXT_LENGTH || b.length < MIN_TEXT_LENGTH
+
+      TextAnalysis.tf_cosine_similarity(a, b)
+    end
+  end
+end

--- a/lib/robot_lab/error.rb
+++ b/lib/robot_lab/error.rb
@@ -41,4 +41,10 @@ module RobotLab
   # @example
   #   raise ToolLoopError, "Circuit breaker: 26 tool calls exceeded max_tool_rounds (25)"
   class ToolLoopError < InferenceError; end
+
+  # Raised when a required optional gem dependency is not installed.
+  #
+  # @example
+  #   raise DependencyError, "Add gem 'classifier', '~> 2.3' to your Gemfile"
+  class DependencyError < ConfigurationError; end
 end

--- a/lib/robot_lab/history_compressor.rb
+++ b/lib/robot_lab/history_compressor.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+module RobotLab
+  # Compresses a robot's conversation history using TF-IDF relevance scoring.
+  #
+  # Old conversation turns are tiered against the most recent context:
+  # - High relevance (score >= keep_threshold)  → kept verbatim
+  # - Medium relevance (drop_threshold..keep_threshold) → summarized or dropped
+  # - Low relevance (score < drop_threshold)    → dropped
+  #
+  # System messages and tool call/result messages are always preserved.
+  # The most recent +recent_turns+ user+assistant pairs are also always kept.
+  #
+  # Requires the optional 'classifier' gem (~> 2.3).
+  #
+  # @example Basic usage from Robot
+  #   robot.compress_history(recent_turns: 3, keep_threshold: 0.6, drop_threshold: 0.2)
+  #
+  # @example With LLM summarizer (separate robot)
+  #   summarizer_robot = RobotLab.build(name: "summarizer", system_prompt: "Summarize concisely.")
+  #   robot.compress_history(
+  #     summarizer: ->(text) { summarizer_robot.run("One sentence: #{text}").reply }
+  #   )
+  class HistoryCompressor
+    # Minimum text length (characters) to score; shorter messages are kept as-is.
+    MIN_SCORE_LENGTH = 20
+
+    # Minimal duck-type for a summary replacement message compatible with
+    # RubyLLM::Chat's message array. Preserves the original message role so
+    # user/assistant turn ordering is maintained after compression.
+    SUMMARY_STRUCT = Struct.new(:role, :content, :tool_calls, :stop_reason) do
+      def text?      = true
+      def tool_use?  = false
+      def system?    = role == :system
+      def user?      = role == :user
+      def assistant? = role == :assistant
+    end
+
+    # @param messages [Array] full @chat.messages array
+    # @param recent_turns [Integer] number of user+assistant turn pairs to protect
+    # @param keep_threshold [Float] score >= this → keep verbatim
+    # @param drop_threshold [Float] score < this → drop
+    # @param summarizer [#call, nil] callable(text) -> String for medium-tier;
+    #                                nil means drop medium-tier
+    # @raise [ArgumentError] if keep_threshold <= drop_threshold
+    def initialize(messages:, recent_turns:, keep_threshold:, drop_threshold:, summarizer:)
+      if keep_threshold <= drop_threshold
+        raise ArgumentError,
+              "keep_threshold (#{keep_threshold}) must be greater than drop_threshold (#{drop_threshold})"
+      end
+
+      @messages        = messages
+      @recent_turns    = recent_turns
+      @keep_threshold  = keep_threshold
+      @drop_threshold  = drop_threshold
+      @summarizer      = summarizer
+    end
+
+    # Execute compression and return the new message array.
+    #
+    # @return [Array] compressed message array
+    def call
+      return @messages if @messages.empty?
+
+      # Classify each message index as pinned (always keep) or scorable
+      pinned_indices   = []
+      scorable_indices = []
+
+      @messages.each_with_index do |msg, idx|
+        if pinned_message?(msg)
+          pinned_indices << idx
+        else
+          scorable_indices << idx
+        end
+      end
+
+      # Nothing scorable, or everything fits inside the recent window: return as-is
+      return @messages if scorable_indices.empty?
+      return @messages if scorable_indices.size <= @recent_turns * 2
+
+      recent_count        = @recent_turns * 2
+      compressible        = scorable_indices[0..-(recent_count + 1)]
+      recent              = scorable_indices[-recent_count..]
+
+      return @messages if compressible.nil? || compressible.empty?
+
+      # Build reference vector from the recent window using stemmed term frequencies.
+      # Term frequencies (no IDF) are used because IDF on a topic-focused corpus
+      # would suppress the very terms that indicate relevance to that topic.
+      recent_texts = recent.filter_map { |i| extract_text(@messages[i]) }
+                           .reject { |t| t.strip.length < MIN_SCORE_LENGTH }
+
+      # No meaningful recent text → cannot score; return unchanged
+      return @messages if recent_texts.empty?
+
+      TextAnalysis.require_classifier!
+
+      recent_vectors = recent_texts.map { |t| TextAnalysis.l2_normalize(t.word_hash) }
+      reference      = mean_vector(recent_vectors)
+
+      # Decide action for each compressible message
+      actions = {}
+      compressible.each do |idx|
+        actions[idx] = score_action(reference, @messages[idx])
+      end
+
+      # Reconstruct the message array in original order
+      build_result(actions)
+    end
+
+    private
+
+    # Determine the action for one compressible message.
+    #
+    # @return [Symbol, String] :keep, :drop, or a summary String
+    def score_action(reference, msg)
+      text = extract_text(msg)
+
+      # Too short to score reliably → keep
+      return :keep if text.nil? || text.strip.length < MIN_SCORE_LENGTH
+
+      vec   = TextAnalysis.l2_normalize(text.word_hash)
+      score = TextAnalysis.cosine_similarity(vec, reference)
+
+      if score >= @keep_threshold
+        :keep
+      elsif score < @drop_threshold
+        :drop
+      elsif @summarizer
+        summary = @summarizer.call(text).to_s.strip
+        summary.empty? ? :drop : summary
+      else
+        :drop
+      end
+    end
+
+    # Build the final message array from the decided actions.
+    def build_result(actions)
+      result = []
+
+      @messages.each_with_index do |msg, idx|
+        action = actions[idx]
+
+        if action.nil?
+          # Pinned or recent: always include
+          result << msg
+        elsif action == :keep
+          result << msg
+        elsif action == :drop
+          # Omit entirely
+        else
+          # action is a summary String; preserve original role to keep turn ordering
+          result << SUMMARY_STRUCT.new(msg.role, action, nil, :stop)
+        end
+      end
+
+      result
+    end
+
+    # True if a message should never be scored or removed.
+    #
+    # System messages and tool-related messages are always pinned.
+    # Assistant messages with no text content (tool call dispatchers)
+    # are also pinned to avoid breaking tool_use/tool_result pairing.
+    def pinned_message?(msg)
+      role = msg.role
+
+      return true if role == :system
+      return true if role == :tool || role == :tool_result
+
+      # Assistant tool-call dispatcher: content is nil or blank
+      if role == :assistant
+        text = extract_text(msg)
+        return true if text.nil? || text.strip.empty?
+      end
+
+      false
+    end
+
+    # Extract plain text from a message's content field.
+    #
+    # @return [String, nil]
+    def extract_text(msg)
+      content = msg.content
+      case content
+      when String then content
+      when Array  then content.filter_map { |p| p[:text] || p["text"] }.join(" ")
+      else nil
+      end
+    end
+
+    # Element-wise mean of a list of sparse vectors.
+    #
+    # @param vectors [Array<Hash{Symbol => Float}>]
+    # @return [Hash{Symbol => Float}]
+    def mean_vector(vectors)
+      return {} if vectors.empty?
+
+      sum = Hash.new(0.0)
+      vectors.each { |v| v.each { |k, val| sum[k] += val } }
+      n = vectors.size.to_f
+      sum.transform_values { |v| v / n }
+    end
+  end
+end

--- a/lib/robot_lab/robot.rb
+++ b/lib/robot_lab/robot.rb
@@ -513,6 +513,36 @@ module RobotLab
       self
     end
 
+    # Compress conversation history using TF-IDF relevance scoring.
+    #
+    # Old turns are tiered against the most recent context:
+    # - High relevance (score >= keep_threshold)          → kept verbatim
+    # - Medium relevance (drop_threshold..keep_threshold) → summarized or dropped
+    # - Low relevance (score < drop_threshold)            → dropped
+    #
+    # System messages and tool call/result messages are always preserved.
+    # The most recent +recent_turns+ pairs are also always kept verbatim.
+    #
+    # Requires the optional 'classifier' gem (~> 2.3).
+    # Raises +DependencyError+ if not installed.
+    #
+    # @param recent_turns [Integer] turn pairs to protect at the end (default 3)
+    # @param keep_threshold [Float] cosine score >= this → keep verbatim (default 0.6)
+    # @param drop_threshold [Float] cosine score < this → drop (default 0.2)
+    # @param summarizer [#call, nil] callable(text) -> String for medium-tier;
+    #                                nil drops medium-tier instead of summarizing
+    # @return [self]
+    def compress_history(recent_turns: 3, keep_threshold: 0.6, drop_threshold: 0.2, summarizer: nil)
+      compressed = HistoryCompressor.new(
+        messages:       @chat.messages,
+        recent_turns:   recent_turns,
+        keep_threshold: keep_threshold,
+        drop_threshold: drop_threshold,
+        summarizer:     summarizer
+      ).call
+      replace_messages(compressed)
+    end
+
     # Return the provider for this robot's chat.
     # Useful for displaying model/provider info without reaching
     # into chat internals.

--- a/lib/robot_lab/text_analysis.rb
+++ b/lib/robot_lab/text_analysis.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module RobotLab
+  # Shared TF-IDF text analysis utilities.
+  #
+  # Wraps +Classifier::TFIDF+ from the optional 'classifier' gem (~> 2.3).
+  # Call +require_classifier!+ before any analysis method to get a descriptive
+  # error if the gem is missing rather than a bare NameError.
+  #
+  # Vectors returned by +transform+ are L2-normalized, so cosine similarity
+  # equals the dot product of two vectors — no magnitude division needed.
+  module TextAnalysis
+    # Attempt to load the classifier gem.
+    #
+    # @raise [DependencyError] if the gem is not installed
+    def self.require_classifier!
+      load_classifier_gem
+    rescue LoadError
+      raise DependencyError,
+            "The 'classifier' gem is required for text analysis features. " \
+            "Add it to your Gemfile: gem 'classifier', '~> 2.3'"
+    end
+
+    # Load the classifier gem. Extracted for testability.
+    #
+    # @api private
+    def self.load_classifier_gem
+      require "classifier"
+    end
+
+    # Fit a TF-IDF model on a corpus of strings.
+    #
+    # @param corpus [Array<String>] non-empty array of document strings
+    # @return [Classifier::TFIDF] fitted model
+    def self.fit(corpus)
+      model = Classifier::TFIDF.new(min_df: 1)
+      model.fit(corpus)
+      model
+    end
+
+    # Transform a string into an L2-normalized TF-IDF term vector.
+    #
+    # @param model [Classifier::TFIDF] a fitted model
+    # @param text [String]
+    # @return [Hash{Symbol => Float}] sparse term vector; empty if no known terms
+    def self.transform(model, text)
+      model.transform(text.to_s) || {}
+    end
+
+    # Cosine similarity between two L2-normalized sparse vectors.
+    #
+    # Since +Classifier::TFIDF+ returns L2-normalized vectors, this is just
+    # a dot product. Result is clamped to [0.0, 1.0] to absorb float noise.
+    #
+    # @param vec_a [Hash{Symbol => Float}]
+    # @param vec_b [Hash{Symbol => Float}]
+    # @return [Float] in [0.0, 1.0]
+    def self.cosine_similarity(vec_a, vec_b)
+      return 0.0 if vec_a.empty? || vec_b.empty?
+
+      [dot(vec_a, vec_b), 1.0].min
+    end
+
+    # Dot product of two sparse vectors (shared keys only).
+    #
+    # @param vec_a [Hash{Symbol => Float}]
+    # @param vec_b [Hash{Symbol => Float}]
+    # @return [Float]
+    def self.dot(vec_a, vec_b)
+      (vec_a.keys & vec_b.keys).sum { |k| vec_a[k] * vec_b[k] }.to_f
+    end
+
+    # L2-normalize a sparse vector.
+    #
+    # @param vec [Hash{Symbol => Numeric}]
+    # @return [Hash{Symbol => Float}] normalized vector; {} if magnitude is zero
+    def self.l2_normalize(vec)
+      magnitude = Math.sqrt(vec.values.sum { |v| v * v }.to_f)
+      return {} if magnitude.zero?
+
+      vec.transform_values { |v| v.to_f / magnitude }
+    end
+
+    # Cosine similarity between two texts using stemmed term-frequency vectors.
+    #
+    # Uses +String#word_hash+ from the classifier gem (stems, removes stopwords)
+    # and L2-normalized term frequencies. Unlike TF-IDF, this does not require
+    # a reference corpus, making it reliable for direct 2-text comparison.
+    # Returns 0.0 when either text is too short to produce a term vector.
+    #
+    # @param text_a [String]
+    # @param text_b [String]
+    # @return [Float] in [0.0, 1.0]
+    def self.tf_cosine_similarity(text_a, text_b)
+      require_classifier!
+
+      vec_a = l2_normalize(text_a.word_hash)
+      vec_b = l2_normalize(text_b.word_hash)
+
+      cosine_similarity(vec_a, vec_b)
+    end
+  end
+end

--- a/robot_lab.gemspec
+++ b/robot_lab.gemspec
@@ -57,4 +57,9 @@ Gem::Specification.new do |spec|
   # Optional MCP transport dependencies (loaded on demand)
   spec.add_dependency "async-http", "~> 0.60"
   spec.add_dependency "async-websocket", "~> 0.30"
+
+  # Optional text analysis dependencies.
+  # Add to your application's Gemfile to enable compress_history and
+  # RobotLab::Convergence:
+  #   gem "classifier", "~> 2.3"
 end

--- a/test/robot_lab/convergence_test.rb
+++ b/test/robot_lab/convergence_test.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RobotLab::ConvergenceTest < Minitest::Test
+  RUBY_TEXT_A = <<~TEXT.strip
+    Ruby on Rails is a web application framework written in Ruby.
+    It follows the MVC pattern and emphasizes convention over configuration.
+    ActiveRecord handles database interactions through an ORM layer.
+  TEXT
+
+  RUBY_TEXT_B = <<~TEXT.strip
+    Rails is a popular Ruby framework for building web applications.
+    It uses the Model-View-Controller architecture and ActiveRecord for database access.
+    Convention over configuration reduces the need for boilerplate code.
+  TEXT
+
+  UNRELATED_TEXT = <<~TEXT.strip
+    The Pacific Ocean is the largest and deepest ocean on Earth.
+    It covers more than thirty percent of the planet surface area.
+    Numerous island chains and coral reefs are found throughout its waters.
+  TEXT
+
+  def simulate_load_error(&block)
+    original = RobotLab::TextAnalysis.method(:load_classifier_gem)
+    RobotLab::TextAnalysis.define_singleton_method(:load_classifier_gem) { raise LoadError }
+    block.call
+  ensure
+    RobotLab::TextAnalysis.define_singleton_method(:load_classifier_gem, &original)
+  end
+
+  # -----------------------------------------------------------------------
+  # Tests that do NOT require the classifier gem
+  # -----------------------------------------------------------------------
+
+  def test_detected_invalid_threshold_high_raises_argument_error
+    assert_raises(ArgumentError) { RobotLab::Convergence.detected?("a", "b", threshold: 1.5) }
+  end
+
+  def test_detected_invalid_threshold_negative_raises_argument_error
+    assert_raises(ArgumentError) { RobotLab::Convergence.detected?("a", "b", threshold: -0.1) }
+  end
+
+  def test_similarity_returns_zero_for_empty_strings
+    assert_in_delta 0.0, RobotLab::Convergence.similarity("", "")
+  end
+
+  def test_similarity_returns_zero_for_short_text
+    assert_in_delta 0.0, RobotLab::Convergence.similarity("hi", "hello")
+  end
+
+  def test_similarity_returns_zero_when_one_text_short
+    assert_in_delta 0.0, RobotLab::Convergence.similarity(RUBY_TEXT_A, "short")
+  end
+
+  # -----------------------------------------------------------------------
+  # LoadError path
+  # -----------------------------------------------------------------------
+
+  def test_similarity_raises_dependency_error_when_classifier_missing
+    simulate_load_error do
+      assert_raises(RobotLab::DependencyError) do
+        RobotLab::Convergence.similarity(RUBY_TEXT_A, RUBY_TEXT_B)
+      end
+    end
+  end
+
+  def test_detected_raises_dependency_error_when_classifier_missing
+    simulate_load_error do
+      assert_raises(RobotLab::DependencyError) do
+        RobotLab::Convergence.detected?(RUBY_TEXT_A, RUBY_TEXT_B)
+      end
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # Tests that require the classifier gem
+  # -----------------------------------------------------------------------
+
+  def setup_classifier_or_skip
+    RobotLab::TextAnalysis.require_classifier!
+  rescue RobotLab::DependencyError
+    skip "classifier gem not available"
+  end
+
+  def test_similarity_similar_texts_returns_high_score
+    setup_classifier_or_skip
+    score = RobotLab::Convergence.similarity(RUBY_TEXT_A, RUBY_TEXT_B)
+    assert_operator score, :>=, 0.4, "similar Ruby/Rails texts should score >= 0.4, got #{score}"
+  end
+
+  def test_similarity_unrelated_texts_returns_lower_score_than_similar
+    setup_classifier_or_skip
+    similar_score   = RobotLab::Convergence.similarity(RUBY_TEXT_A, RUBY_TEXT_B)
+    unrelated_score = RobotLab::Convergence.similarity(RUBY_TEXT_A, UNRELATED_TEXT)
+    assert_operator similar_score, :>, unrelated_score,
+                    "similar (#{similar_score}) should beat unrelated (#{unrelated_score})"
+  end
+
+  def test_similarity_is_in_range
+    setup_classifier_or_skip
+    score = RobotLab::Convergence.similarity(RUBY_TEXT_A, RUBY_TEXT_B)
+    assert_operator score, :>=, 0.0
+    assert_operator score, :<=, 1.0
+  end
+
+  def test_detected_true_when_similar_above_threshold
+    setup_classifier_or_skip
+    assert RobotLab::Convergence.detected?(RUBY_TEXT_A, RUBY_TEXT_B, threshold: 0.4),
+           "similar Ruby texts should converge at threshold 0.4"
+  end
+
+  def test_detected_false_when_unrelated_above_threshold
+    setup_classifier_or_skip
+    refute RobotLab::Convergence.detected?(RUBY_TEXT_A, UNRELATED_TEXT, threshold: 0.5),
+           "unrelated texts should not converge at threshold 0.5"
+  end
+
+  def test_detected_uses_default_threshold_for_identical_texts
+    setup_classifier_or_skip
+    assert RobotLab::Convergence.detected?(RUBY_TEXT_A, RUBY_TEXT_A),
+           "identical texts should always converge at the default threshold"
+  end
+
+  def test_similarity_symmetric
+    setup_classifier_or_skip
+    ab = RobotLab::Convergence.similarity(RUBY_TEXT_A, RUBY_TEXT_B)
+    ba = RobotLab::Convergence.similarity(RUBY_TEXT_B, RUBY_TEXT_A)
+    assert_in_delta ab, ba, 0.001, "similarity should be symmetric"
+  end
+
+  def test_similarity_identical_texts_near_one
+    setup_classifier_or_skip
+    score = RobotLab::Convergence.similarity(RUBY_TEXT_A, RUBY_TEXT_A)
+    assert_operator score, :>=, 0.99, "identical texts should score near 1.0, got #{score}"
+  end
+end

--- a/test/robot_lab/history_compressor_test.rb
+++ b/test/robot_lab/history_compressor_test.rb
@@ -1,0 +1,276 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RobotLab::HistoryCompressorTest < Minitest::Test
+  # Minimal message struct that quacks like RubyLLM::Message
+  FakeMsg = Struct.new(:role, :content, :tool_calls)
+
+  def msg(role, content)
+    FakeMsg.new(role.to_sym, content, nil)
+  end
+
+  def system_msg(content = "You are helpful.")  = msg(:system, content)
+  def user_msg(content)                         = msg(:user, content)
+  def assistant_msg(content)                    = msg(:assistant, content)
+  def tool_result_msg                           = msg(:tool_result, '{ "result": 42 }')
+  def tool_call_msg                             = msg(:assistant, nil)   # nil content = tool dispatcher
+
+  def compressor(messages:, recent_turns: 2, keep: 0.6, drop: 0.2, summarizer: nil)
+    RobotLab::HistoryCompressor.new(
+      messages:       messages,
+      recent_turns:   recent_turns,
+      keep_threshold: keep,
+      drop_threshold: drop,
+      summarizer:     summarizer
+    )
+  end
+
+  def simulate_load_error(&block)
+    original = RobotLab::TextAnalysis.method(:load_classifier_gem)
+    RobotLab::TextAnalysis.define_singleton_method(:load_classifier_gem) { raise LoadError }
+    block.call
+  ensure
+    RobotLab::TextAnalysis.define_singleton_method(:load_classifier_gem, &original)
+  end
+
+  # -----------------------------------------------------------------------
+  # Edge cases — no classifier gem needed
+  # -----------------------------------------------------------------------
+
+  def test_empty_messages_returns_empty
+    assert_equal [], compressor(messages: []).call
+  end
+
+  def test_system_only_returns_unchanged
+    msgs = [system_msg]
+    assert_equal msgs, compressor(messages: msgs).call
+  end
+
+  def test_too_few_scorable_messages_returns_unchanged
+    msgs = [system_msg, user_msg("Hello"), assistant_msg("Hi")]
+    assert_equal msgs, compressor(messages: msgs, recent_turns: 2).call
+  end
+
+  def test_tool_result_messages_always_preserved
+    msgs = [system_msg, tool_result_msg]
+    assert_includes compressor(messages: msgs).call, tool_result_msg
+  end
+
+  def test_tool_call_dispatcher_always_preserved
+    msgs = [system_msg, tool_call_msg]
+    assert_includes compressor(messages: msgs).call, tool_call_msg
+  end
+
+  def test_recent_turns_always_present
+    msgs = [
+      system_msg,
+      user_msg("Old question"),     # compressible
+      assistant_msg("Old answer"),  # compressible
+      user_msg("Recent A"),         # protected
+      assistant_msg("Answer A"),    # protected
+      user_msg("Recent B"),         # protected
+      assistant_msg("Answer B")     # protected
+    ]
+    result = compressor(messages: msgs, recent_turns: 2).call
+    [3, 4, 5, 6].each { |i| assert_includes result, msgs[i] }
+  end
+
+  def test_recent_turns_exceeds_history_returns_unchanged
+    msgs = [system_msg, user_msg("q"), assistant_msg("a")]
+    assert_equal msgs, compressor(messages: msgs, recent_turns: 10).call
+  end
+
+  def test_keep_threshold_must_exceed_drop_threshold
+    assert_raises(ArgumentError) { compressor(messages: [], keep: 0.3, drop: 0.5) }
+  end
+
+  def test_equal_thresholds_raise_argument_error
+    assert_raises(ArgumentError) { compressor(messages: [], keep: 0.5, drop: 0.5) }
+  end
+
+  def test_system_message_always_in_result
+    msgs = [
+      system_msg,
+      user_msg("old turn topic A"),
+      assistant_msg("old answer topic A"),
+      user_msg("recent Rails question"),
+      assistant_msg("recent Rails answer"),
+      user_msg("recent Rails followup"),
+      assistant_msg("recent Rails followup answer")
+    ]
+    result = compressor(messages: msgs, recent_turns: 2).call
+    assert result.any? { |m| m.role == :system }, "system message should always be in result"
+  end
+
+  # -----------------------------------------------------------------------
+  # Classifier-dependent tests
+  # -----------------------------------------------------------------------
+
+  RAILS_TURN    = "Ruby on Rails is a web framework using the MVC architecture and ActiveRecord ORM"
+  OCEAN_TURN    = "The Pacific Ocean is the largest body of water covering most of the Earth surface"
+  RECENT_RAILS  = "How does Rails routing work with ActiveRecord associations?"
+  RECENT_RAILS2 = "What is the Rails convention over configuration principle?"
+
+  def setup_classifier_or_skip
+    RobotLab::TextAnalysis.require_classifier!
+  rescue RobotLab::DependencyError
+    skip "classifier gem not available"
+  end
+
+  def test_relevant_old_turn_kept
+    setup_classifier_or_skip
+
+    msgs = [
+      system_msg,
+      user_msg(RAILS_TURN),
+      assistant_msg("Rails uses MVC and has ActiveRecord for database access"),
+      user_msg(RECENT_RAILS),
+      assistant_msg("Rails routing maps URLs to controller actions via routes.rb"),
+      user_msg(RECENT_RAILS2),
+      assistant_msg("Convention over configuration means sensible defaults")
+    ]
+
+    result = compressor(messages: msgs, recent_turns: 2, keep: 0.1, drop: 0.05).call
+
+    assert_includes result, msgs[1], "relevant Rails turn should be kept"
+    assert_includes result, msgs[2], "relevant Rails answer should be kept"
+  end
+
+  def test_irrelevant_old_turn_dropped
+    setup_classifier_or_skip
+
+    msgs = [
+      system_msg,
+      user_msg(OCEAN_TURN),
+      assistant_msg("The ocean is vast and deep with coral reefs"),
+      user_msg(RECENT_RAILS),
+      assistant_msg("Rails routing maps URLs to controller actions via routes.rb"),
+      user_msg(RECENT_RAILS2),
+      assistant_msg("Convention over configuration means sensible defaults")
+    ]
+
+    result = compressor(messages: msgs, recent_turns: 2, keep: 0.5, drop: 0.1).call
+
+    refute_includes result, msgs[1], "irrelevant ocean turn should be dropped"
+    refute_includes result, msgs[2], "irrelevant ocean answer should be dropped"
+  end
+
+  def test_summarizer_called_for_medium_tier
+    setup_classifier_or_skip
+    calls = []
+    summarizer = ->(text) { calls << text; "SUMMARY: #{text[0..20]}" }
+
+    # Craft messages where old turns may fall in medium relevance
+    msgs = [
+      system_msg,
+      user_msg("Rails has some ocean-themed routing metaphors perhaps"),
+      assistant_msg("Some Rails patterns relate loosely to various concepts"),
+      user_msg(RECENT_RAILS),
+      assistant_msg("Rails routing maps URLs to controller actions"),
+      user_msg(RECENT_RAILS2),
+      assistant_msg("Convention over configuration means sensible defaults")
+    ]
+
+    result = compressor(messages: msgs, recent_turns: 2, keep: 0.9, drop: 0.01, summarizer: summarizer).call
+    assert_kind_of Array, result
+    assert result.any? { |m| m.role == :system }
+  end
+
+  def test_nil_summarizer_drops_medium_tier
+    setup_classifier_or_skip
+
+    msgs = [
+      system_msg,
+      user_msg("Rails has some ocean-themed routing patterns"),
+      assistant_msg("Mixed topic about ocean and Rails patterns"),
+      user_msg(RECENT_RAILS),
+      assistant_msg("Rails routing maps URLs to controller actions"),
+      user_msg(RECENT_RAILS2),
+      assistant_msg("Convention over configuration means sensible defaults")
+    ]
+
+    result = compressor(messages: msgs, recent_turns: 2, keep: 0.9, drop: 0.01, summarizer: nil).call
+    assert_kind_of Array, result
+    assert result.any? { |m| m.role == :system }
+  end
+
+  def test_summarizer_preserves_user_role
+    setup_classifier_or_skip
+    summaries = []
+    summarizer = ->(text) { s = "Summary: #{text[0..15]}"; summaries << s; s }
+
+    msgs = [
+      system_msg,
+      user_msg("Rails has some ocean-themed routing metaphors perhaps"),
+      assistant_msg("Some Rails patterns relate loosely to various concepts"),
+      user_msg(RECENT_RAILS),
+      assistant_msg("Rails routing maps URLs to controller actions"),
+      user_msg(RECENT_RAILS2),
+      assistant_msg("Convention over configuration means sensible defaults")
+    ]
+
+    result = compressor(messages: msgs, recent_turns: 2, keep: 0.9, drop: 0.01, summarizer: summarizer).call
+
+    # Any summarized messages must preserve their original role
+    result.each do |m|
+      next unless summaries.include?(m.content)
+      original = msgs.find { |o| summaries.any? { |s| m.content == s } }
+      # user summaries must respond true to user?, assistant summaries to assistant?
+      if m.role == :user
+        assert m.user?, "summarized user message should respond true to user?"
+        refute m.assistant?, "summarized user message should not respond true to assistant?"
+      elsif m.role == :assistant
+        assert m.assistant?, "summarized assistant message should respond true to assistant?"
+        refute m.user?, "summarized assistant message should not respond true to user?"
+      end
+    end
+  end
+
+  def test_summarizer_maintains_alternating_roles
+    setup_classifier_or_skip
+    summarizer = ->(text) { "Brief: #{text[0..20]}" }
+
+    msgs = [
+      system_msg,
+      user_msg("Rails has some ocean-themed routing metaphors perhaps"),
+      assistant_msg("Some Rails patterns relate loosely to various concepts"),
+      user_msg(RECENT_RAILS),
+      assistant_msg("Rails routing maps URLs to controller actions"),
+      user_msg(RECENT_RAILS2),
+      assistant_msg("Convention over configuration means sensible defaults")
+    ]
+
+    result = compressor(messages: msgs, recent_turns: 2, keep: 0.9, drop: 0.01, summarizer: summarizer).call
+
+    # After system, roles must alternate user/assistant
+    non_system = result.reject { |m| m.role == :system }
+    non_system.each_with_index do |m, i|
+      expected = i.even? ? :user : :assistant
+      assert_equal expected, m.role,
+                   "expected #{expected} at position #{i}, got #{m.role}"
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # LoadError path
+  # -----------------------------------------------------------------------
+
+  def test_raises_dependency_error_when_classifier_missing
+    msgs = [
+      system_msg,
+      user_msg("this is a longer old question about something interesting"),
+      assistant_msg("this is a longer old answer explaining that something"),
+      user_msg("recent question about Ruby on Rails routing conventions"),
+      assistant_msg("recent answer about Rails routing and controller actions"),
+      user_msg("recent follow-up question about Rails convention over configuration"),
+      assistant_msg("recent answer about Rails convention over configuration principles")
+    ]
+
+    simulate_load_error do
+      assert_raises(RobotLab::DependencyError) do
+        compressor(messages: msgs, recent_turns: 2).call
+      end
+    end
+  end
+end

--- a/test/robot_lab/text_analysis_test.rb
+++ b/test/robot_lab/text_analysis_test.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RobotLab::TextAnalysisTest < Minitest::Test
+  # -----------------------------------------------------------------------
+  # dot — pure math, no classifier gem needed
+  # -----------------------------------------------------------------------
+
+  def test_dot_shared_keys
+    a = { foo: 0.5, bar: 0.5 }
+    b = { bar: 0.5, baz: 0.5 }
+    assert_in_delta 0.25, RobotLab::TextAnalysis.dot(a, b)
+  end
+
+  def test_dot_no_shared_keys
+    a = { foo: 1.0 }
+    b = { bar: 1.0 }
+    assert_in_delta 0.0, RobotLab::TextAnalysis.dot(a, b)
+  end
+
+  def test_dot_empty_vectors
+    assert_in_delta 0.0, RobotLab::TextAnalysis.dot({}, {})
+  end
+
+  # -----------------------------------------------------------------------
+  # l2_normalize
+  # -----------------------------------------------------------------------
+
+  def test_l2_normalize_unit_vector
+    result = RobotLab::TextAnalysis.l2_normalize({ a: 3.0, b: 4.0 })
+    assert_in_delta 0.6, result[:a], 0.001
+    assert_in_delta 0.8, result[:b], 0.001
+  end
+
+  def test_l2_normalize_zero_vector_returns_empty
+    assert_equal({}, RobotLab::TextAnalysis.l2_normalize({ a: 0.0 }))
+  end
+
+  def test_l2_normalize_empty_vector_returns_empty
+    assert_equal({}, RobotLab::TextAnalysis.l2_normalize({}))
+  end
+
+  # -----------------------------------------------------------------------
+  # cosine_similarity — pure math, no classifier gem needed
+  # -----------------------------------------------------------------------
+
+  def test_cosine_similarity_identical_unit_vectors
+    v = { a: 1.0 }
+    assert_in_delta 1.0, RobotLab::TextAnalysis.cosine_similarity(v, v)
+  end
+
+  def test_cosine_similarity_orthogonal_vectors
+    a = { x: 1.0 }
+    b = { y: 1.0 }
+    assert_in_delta 0.0, RobotLab::TextAnalysis.cosine_similarity(a, b)
+  end
+
+  def test_cosine_similarity_partial_overlap
+    a = { x: 0.707, y: 0.707 }
+    b = { x: 1.0 }
+    result = RobotLab::TextAnalysis.cosine_similarity(a, b)
+    assert_operator result, :>, 0.0
+    assert_operator result, :<, 1.0
+  end
+
+  def test_cosine_similarity_empty_vec_a
+    assert_in_delta 0.0, RobotLab::TextAnalysis.cosine_similarity({}, { a: 1.0 })
+  end
+
+  def test_cosine_similarity_empty_vec_b
+    assert_in_delta 0.0, RobotLab::TextAnalysis.cosine_similarity({ a: 1.0 }, {})
+  end
+
+  def test_cosine_similarity_clamps_above_one
+    a = { x: 0.9999999 }
+    b = { x: 1.0000001 }
+    result = RobotLab::TextAnalysis.cosine_similarity(a, b)
+    assert_operator result, :<=, 1.0
+  end
+
+  # -----------------------------------------------------------------------
+  # require_classifier! — LoadError path (define_singleton_method pattern)
+  # -----------------------------------------------------------------------
+
+  def test_require_classifier_wraps_load_error_as_dependency_error
+    original = RobotLab::TextAnalysis.method(:load_classifier_gem)
+    RobotLab::TextAnalysis.define_singleton_method(:load_classifier_gem) { raise LoadError, "no classifier" }
+    assert_raises(RobotLab::DependencyError) { RobotLab::TextAnalysis.require_classifier! }
+  ensure
+    RobotLab::TextAnalysis.define_singleton_method(:load_classifier_gem, &original)
+  end
+
+  def test_dependency_error_message_includes_install_hint
+    original = RobotLab::TextAnalysis.method(:load_classifier_gem)
+    RobotLab::TextAnalysis.define_singleton_method(:load_classifier_gem) { raise LoadError, "no classifier" }
+    error = assert_raises(RobotLab::DependencyError) { RobotLab::TextAnalysis.require_classifier! }
+    assert_match(/classifier/, error.message)
+    assert_match(/Gemfile/, error.message)
+  ensure
+    RobotLab::TextAnalysis.define_singleton_method(:load_classifier_gem, &original)
+  end
+
+  # -----------------------------------------------------------------------
+  # fit / transform — require classifier gem
+  # -----------------------------------------------------------------------
+
+  def setup_classifier_or_skip
+    RobotLab::TextAnalysis.require_classifier!
+  rescue RobotLab::DependencyError
+    skip "classifier gem not available"
+  end
+
+  def test_fit_returns_tfidf_model
+    setup_classifier_or_skip
+    corpus = ["the quick brown fox", "jumps over the lazy dog"]
+    model  = RobotLab::TextAnalysis.fit(corpus)
+    refute_nil model
+    assert_respond_to model, :transform
+  end
+
+  def test_transform_returns_hash_with_symbol_keys
+    setup_classifier_or_skip
+    corpus = ["ruby programming language", "python programming language"]
+    model  = RobotLab::TextAnalysis.fit(corpus)
+    vec    = RobotLab::TextAnalysis.transform(model, "ruby programming")
+    assert_kind_of Hash, vec
+    assert vec.keys.all? { |k| k.is_a?(Symbol) }, "expected Symbol keys"
+    assert vec.values.all? { |v| v.is_a?(Float) }, "expected Float values"
+  end
+
+  def test_transform_empty_text_returns_hash
+    setup_classifier_or_skip
+    corpus = ["hello world"]
+    model  = RobotLab::TextAnalysis.fit(corpus)
+    vec    = RobotLab::TextAnalysis.transform(model, "")
+    assert_kind_of Hash, vec
+  end
+
+  def test_transform_unknown_terms_returns_sparse_or_empty
+    setup_classifier_or_skip
+    corpus = ["hello world"]
+    model  = RobotLab::TextAnalysis.fit(corpus)
+    vec    = RobotLab::TextAnalysis.transform(model, "zzz xyz qqqq")
+    assert_kind_of Hash, vec
+  end
+
+  # -----------------------------------------------------------------------
+  # tf_cosine_similarity — word_hash based
+  # -----------------------------------------------------------------------
+
+  def test_tf_cosine_similar_texts_score_higher_than_unrelated
+    setup_classifier_or_skip
+    rails_a = "Ruby on Rails is a web framework built on top of the Ruby programming language"
+    rails_b = "Rails provides a structure for web applications using the Ruby language and MVC"
+    ocean   = "The Pacific Ocean is the largest body of water on the surface of the Earth"
+
+    sim_rails = RobotLab::TextAnalysis.tf_cosine_similarity(rails_a, rails_b)
+    sim_ocean = RobotLab::TextAnalysis.tf_cosine_similarity(rails_a, ocean)
+
+    assert_operator sim_rails, :>, sim_ocean,
+                    "Rails/Rails similarity (#{sim_rails}) should exceed Rails/Ocean (#{sim_ocean})"
+  end
+
+  def test_tf_cosine_identical_texts_returns_one
+    setup_classifier_or_skip
+    text  = "Ruby on Rails is a popular web application framework for building great software"
+    score = RobotLab::TextAnalysis.tf_cosine_similarity(text, text)
+    assert_in_delta 1.0, score, 0.001
+  end
+
+  def test_tf_cosine_raises_dependency_error_when_classifier_missing
+    original = RobotLab::TextAnalysis.method(:load_classifier_gem)
+    RobotLab::TextAnalysis.define_singleton_method(:load_classifier_gem) { raise LoadError }
+    assert_raises(RobotLab::DependencyError) do
+      RobotLab::TextAnalysis.tf_cosine_similarity("hello world test", "hello world test")
+    end
+  ensure
+    RobotLab::TextAnalysis.define_singleton_method(:load_classifier_gem, &original)
+  end
+
+  def test_similar_tfidf_texts_have_higher_score_than_dissimilar
+    setup_classifier_or_skip
+    corpus = [
+      "Ruby on Rails is a web framework",
+      "ActiveRecord is the Rails ORM layer",
+      "The Pacific Ocean covers most of the globe"
+    ]
+    model = RobotLab::TextAnalysis.fit(corpus)
+
+    rails_vec  = RobotLab::TextAnalysis.transform(model, corpus[0])
+    active_vec = RobotLab::TextAnalysis.transform(model, corpus[1])
+    ocean_vec  = RobotLab::TextAnalysis.transform(model, corpus[2])
+
+    rails_active_sim = RobotLab::TextAnalysis.cosine_similarity(rails_vec, active_vec)
+    rails_ocean_sim  = RobotLab::TextAnalysis.cosine_similarity(rails_vec, ocean_vec)
+
+    assert_operator rails_active_sim, :>=, rails_ocean_sim,
+                    "Rails/ActiveRecord should score >= Rails/Ocean (got #{rails_active_sim} vs #{rails_ocean_sim})"
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,7 @@ $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 ENV['ROBOT_LAB_TEMPLATE_PATH'] ||= File.expand_path('../examples/prompts', __dir__)
 
 require 'robot_lab'
+require 'simple_flow'   # ensure SimpleFlow is loaded regardless of test order
 require 'minitest/autorun'
 
 # Set dummy API key so RubyLLM model resolution doesn't fail in unit tests


### PR DESCRIPTION
## Summary

- **`RobotLab::TextAnalysis`** — shared TF/word_hash utilities: `dot`, `l2_normalize`, `cosine_similarity`, `tf_cosine_similarity`, `fit`/`transform` (TF-IDF). All math is pure Ruby with no classifier dep; only `require_classifier!` and methods that call `word_hash` need the gem.
- **`RobotLab::Convergence`** — detects semantic agreement between two texts via stemmed TF cosine similarity. `similarity(a, b)` → Float; `detected?(a, b, threshold: 0.85)` → Boolean. Enables a router fast-path that skips the reconciler when two verifiers already agree.
- **`RobotLab::HistoryCompressor`** — scores old conversation turns against the mean of recent turns and keeps/drops/summarizes them. `robot.compress_history(recent_turns:, keep_threshold:, drop_threshold:, summarizer:)` operates in-place on the chat. System, tool, and recent messages are always preserved. Summarized messages retain their original role so user/assistant alternation is maintained.
- **`RobotLab::DependencyError`** — new error subclass raised with an install hint when `classifier` gem is absent.
- **Optional dep pattern** — `classifier` (~> 2.3) is not in `add_dependency`; users add it to their own Gemfile. `LoadError` at runtime → `DependencyError` with hint.
- **Key implementation insight** — TF-IDF on a small, topic-focused corpus collapses shared terms to IDF ≈ 0, making similar texts score unexpectedly low. Solution: use raw `String#word_hash` TF vectors (stemmed, stopword-filtered) + L2-normalize for all direct text comparisons.
- **`test/test_helper.rb`** — added `require 'simple_flow'` to fix a pre-existing load-order race that caused 3 `robot_test.rb` tests to raise `NameError: uninitialized constant SimpleFlow` when text analysis tests ran first.

## New files

| File | Purpose |
|---|---|
| `lib/robot_lab/text_analysis.rb` | Shared TF/cosine utilities |
| `lib/robot_lab/convergence.rb` | Semantic convergence detection |
| `lib/robot_lab/history_compressor.rb` | Conversation history compression |
| `test/robot_lab/text_analysis_test.rb` | 201 lines, pure-math + classifier-dep tests |
| `test/robot_lab/convergence_test.rb` | Similarity scores, detected?, LoadError path |
| `test/robot_lab/history_compressor_test.rb` | Edge cases, scoring, role preservation, LoadError |
| `examples/22_context_compression.rb` | Drop-mode and summarizer demo (no LLM calls) |
| `examples/23_convergence.rb` | Score gradient demo + router fast-path recipe |
| `docs/guides/observability.md` | Phase 2 sections: compression + convergence |

## Test plan

- [ ] `bundle exec rake test` — 992 runs, 0 failures, 0 errors, 0 skips, 98.85% coverage
- [ ] `ruby examples/22_context_compression.rb` — verify drop/summarize output and correct alternating roles
- [ ] `ruby examples/23_convergence.rb` — verify similarity gradient (1.0 → 0.68 → 0.57 → 0.06) and fast-path simulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)