### PR TITLE
feat(phase-3): structured delegation and memory notification coalescing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@
 - <strong>Tool Loop Circuit Breaker</strong> - <code>max_tool_rounds:</code> guards against runaway tool call loops<br>
 - <strong>Learning Accumulation</strong> - <code>robot.learn()</code> builds up cross-run observations with deduplication<br>
 - <strong>Context Window Compression</strong> - <code>robot.compress_history()</code> prunes irrelevant old turns via TF cosine scoring<br>
-- <strong>Convergence Detection</strong> - <code>RobotLab::Convergence</code> detects when independent agents agree, enabling reconciler fast-path
+- <strong>Convergence Detection</strong> - <code>RobotLab::Convergence</code> detects when independent agents agree, enabling reconciler fast-path<br>
+- <strong>Structured Delegation</strong> - <code>robot.delegate(to:, task:)</code> sync or async inter-robot calls with duration and token metadata; async fan-out via <code>DelegationFuture</code>
 </td>
 </tr>
 </table>

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -7,6 +7,7 @@ Facilities that help you monitor, control, improve, and scale robot behaviour:
 - **Learning Accumulation** — build up cross-run observations that guide future runs
 - **Context Window Compression** — prune irrelevant history to stay within token budgets
 - **Convergence Detection** — detect when independent agents reach the same conclusion
+- **Structured Delegation** — synchronous inter-robot calls with duration and token metadata
 
 ---
 
@@ -392,6 +393,88 @@ gem "classifier", "~> 2.3"
 
 ---
 
+---
+
+## Structured Delegation
+
+### The Problem
+
+RobotLab has two existing patterns for one robot to involve another:
+
+- **Pipelines** — predefined sequences where robots share memory and run in order
+- **Bus messaging** — fire-and-forget pub/sub with no return value
+
+Neither gives you a synchronous call that returns a result with provenance and cost metadata. `delegate` fills that gap.
+
+### Synchronous delegation
+
+Blocks until the delegatee finishes and returns a `RobotResult` annotated with provenance and timing:
+
+```ruby
+result = manager.delegate(to: specialist, task: "Analyze this data: ...")
+
+puts result.reply          # specialist's answer
+puts result.robot_name     # => "specialist"   (who did the work)
+puts result.delegated_by   # => "manager"      (who asked)
+puts result.duration       # => 1.43           (wall-clock seconds)
+puts result.input_tokens   # => 812
+puts result.output_tokens  # => 94
+```
+
+All keyword arguments are forwarded to the delegatee's `run()`:
+
+```ruby
+result = manager.delegate(to: worker, task: "hello", company_name: "Acme")
+```
+
+### Asynchronous delegation — parallel fan-out
+
+Pass `async: true` to get a `DelegationFuture` back immediately. The delegatee runs in a background thread. Call `future.value` to block for the result, or `future.resolved?` to poll without blocking.
+
+```ruby
+# Fire both delegations simultaneously
+f1 = manager.delegate(to: summarizer, task: "Summarize: #{doc}", async: true)
+f2 = manager.delegate(to: analyst,    task: "Key metric: #{doc}", async: true)
+
+# Both are running in parallel here
+puts f1.resolved?   # false (probably)
+
+# Collect when ready (optional timeout in seconds)
+summary  = f1.value(timeout: 30)
+analysis = f2.value(timeout: 30)
+```
+
+If the delegatee raises an error, `future.value` re-raises it. If `timeout:` expires before the result arrives, `DelegationFuture::DelegationTimeout` is raised.
+
+### When to Use Each Pattern
+
+| Pattern | Return value | Concurrent | Use when |
+|---|---|---|---|
+| `pipeline` | shared memory | yes (parallel groups) | fixed workflow graph |
+| `bus` messaging | none (fire-and-forget) | yes | notify without waiting for a reply |
+| `delegate` | `RobotResult` with metadata | no | need the result back, one at a time |
+| `delegate(async: true)` | `DelegationFuture` | yes | parallel fan-out, collect results later |
+
+### Full Example
+
+```ruby
+manager    = RobotLab.build(name: "manager",    system_prompt: "You are a project manager.")
+summarizer = RobotLab.build(name: "summarizer", system_prompt: "Summarize in 1-2 sentences.")
+analyst    = RobotLab.build(name: "analyst",    system_prompt: "Identify the key metric.")
+
+# Parallel fan-out
+f1 = manager.delegate(to: summarizer, task: "Summarize: #{document}", async: true)
+f2 = manager.delegate(to: analyst,    task: "Key metric: #{document}", async: true)
+
+summary  = f1.value(timeout: 60)
+analysis = f2.value(timeout: 60)
+
+puts "#{summary.robot_name} (#{summary.duration.round(2)}s): #{summary.reply}"
+puts "#{analysis.robot_name} (#{analysis.duration.round(2)}s): #{analysis.reply}"
+```
+
+---
+
 ## See Also
 
 - [Robot API](../api/core/robot.md#token--cost-tracking)
@@ -400,3 +483,4 @@ gem "classifier", "~> 2.3"
 - [Example 21 — Learning Accumulation Loop](../../examples/21_learning_loop.rb)
 - [Example 22 — Context Window Compression](../../examples/22_context_compression.rb)
 - [Example 23 — Convergence Detection](../../examples/23_convergence.rb)
+- [Example 24 — Structured Delegation](../../examples/24_structured_delegation.rb)

--- a/examples/24_structured_delegation.rb
+++ b/examples/24_structured_delegation.rb
@@ -1,0 +1,150 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Example 24: Structured Delegation
+#
+# Demonstrates robot.delegate(to:, task:) for structured inter-robot calls,
+# in both synchronous (blocking) and asynchronous (parallel fan-out) modes.
+#
+# Demonstrates:
+#   - robot.delegate(to:, task:)              — sync: blocks, returns RobotResult
+#   - robot.delegate(to:, task:, async: true) — async: returns DelegationFuture
+#   - future.value / future.value(timeout: N) — block until result ready
+#   - future.resolved?                        — non-blocking poll
+#   - result.delegated_by — which robot delegated
+#   - result.robot_name   — which robot did the work
+#   - result.duration     — wall-clock seconds for the delegated call
+#   - result.input_tokens / result.output_tokens — delegatee's token usage
+#   - Contrast with bus messaging (fire-and-forget) and pipelines (predefined)
+#
+# Usage:
+#   ANTHROPIC_API_KEY=your_key ruby examples/24_structured_delegation.rb
+
+ENV["ROBOT_LAB_TEMPLATE_PATH"] ||= File.join(__dir__, "prompts")
+
+require_relative "../lib/robot_lab"
+
+puts "=" * 60
+puts "Example 24: Structured Delegation"
+puts "=" * 60
+puts
+
+# ---------------------------------------------------------------------------
+# Build a manager and two specialist robots
+# ---------------------------------------------------------------------------
+manager = RobotLab.build(
+  name:          "manager",
+  system_prompt: "You are a project manager. Delegate tasks concisely."
+)
+
+summarizer = RobotLab.build(
+  name:          "summarizer",
+  system_prompt: "You are a concise summarizer. Produce a 1-2 sentence summary."
+)
+
+analyst = RobotLab.build(
+  name:          "analyst",
+  system_prompt: "You are a data analyst. Identify the key metric in one sentence."
+)
+
+# ---------------------------------------------------------------------------
+# Manager delegates to each specialist in turn
+# ---------------------------------------------------------------------------
+document = <<~TEXT
+  Q4 revenue came in at $4.2M, up 18% year-over-year. Customer acquisition
+  cost dropped to $120, the lowest in three years. Churn held steady at 2.1%.
+  Net promoter score improved from 42 to 58. The mobile app drove 34% of new
+  sign-ups, compared to 19% in Q3.
+TEXT
+
+puts "Document:"
+puts document
+puts "-" * 60
+
+# ---------------------------------------------------------------------------
+# Synchronous delegation — sequential, blocks until each result arrives
+# ---------------------------------------------------------------------------
+puts "── Synchronous (sequential) ──────────────────────────────"
+puts
+
+puts "Delegating to summarizer (blocking)..."
+summary_result = manager.delegate(to: summarizer, task: "Summarize this report:\n\n#{document}")
+
+puts "Summary (from #{summary_result.robot_name}, delegated by #{summary_result.delegated_by}):"
+puts "  #{summary_result.reply}"
+puts "  Duration: #{"%.2f" % summary_result.duration}s | " \
+     "Tokens: #{summary_result.input_tokens} in / #{summary_result.output_tokens} out"
+puts
+
+puts "Delegating to analyst (blocking)..."
+analysis_result = manager.delegate(to: analyst, task: "What is the single most important metric here?\n\n#{document}")
+
+puts "Analysis (from #{analysis_result.robot_name}, delegated by #{analysis_result.delegated_by}):"
+puts "  #{analysis_result.reply}"
+puts "  Duration: #{"%.2f" % analysis_result.duration}s | " \
+     "Tokens: #{analysis_result.input_tokens} in / #{analysis_result.output_tokens} out"
+puts
+
+# ---------------------------------------------------------------------------
+# Asynchronous delegation — parallel fan-out, results collected later
+# ---------------------------------------------------------------------------
+puts "── Asynchronous (parallel fan-out) ───────────────────────"
+puts
+
+# Fresh robots — each delegate call should start from a clean slate
+async_summarizer = RobotLab.build(
+  name:          "summarizer",
+  system_prompt: "You are a concise summarizer. Produce a 1-2 sentence summary."
+)
+async_analyst = RobotLab.build(
+  name:          "analyst",
+  system_prompt: "You are a data analyst. Identify the key metric in one sentence."
+)
+
+puts "Firing both delegations in parallel..."
+t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+f_summary  = manager.delegate(to: async_summarizer, task: "Summarize this report:\n\n#{document}",                     async: true)
+f_analysis = manager.delegate(to: async_analyst,    task: "What is the single most important metric?\n\n#{document}", async: true)
+
+puts "Both futures launched. Futures resolved? " \
+     "summary=#{f_summary.resolved?} analysis=#{f_analysis.resolved?}"
+puts "Collecting results..."
+
+summary  = f_summary.value(timeout: 60)
+analysis = f_analysis.value(timeout: 60)
+
+elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+
+puts
+puts "Summary  (#{summary.robot_name}):  #{summary.reply}"
+puts "Analysis (#{analysis.robot_name}): #{analysis.reply}"
+puts
+puts "Total wall time with parallelism: #{"%.2f" % elapsed}s " \
+     "(vs ~#{"%.2f" % (summary.duration + analysis.duration)}s sequential)"
+puts
+
+# ---------------------------------------------------------------------------
+# Contrast with the alternatives
+# ---------------------------------------------------------------------------
+puts "=" * 60
+puts "When to use delegate vs. the alternatives"
+puts "=" * 60
+puts <<~TEXT
+
+  bus messaging       — fire-and-forget; no return value; async
+                        use when: you want to notify without waiting
+
+  pipeline            — predefined sequence; robots share memory
+                        use when: you have a fixed workflow graph
+
+  delegate()          — synchronous; blocks; returns RobotResult with metadata
+                        use when: one robot needs the result of another's work
+
+  delegate(async:true) — returns DelegationFuture immediately
+                         use when: you want to run multiple delegates in
+                         parallel and collect results when ready
+
+TEXT
+
+puts "Done."

--- a/examples/README.md
+++ b/examples/README.md
@@ -50,6 +50,7 @@ examples/
   21_learning_loop.rb         # Learning accumulation across runs with robot.learn
   22_context_compression.rb   # Context window compression with HistoryCompressor
   23_convergence.rb           # Debate convergence detection and reconciler fast-path
+  24_structured_delegation.rb # Structured delegation with duration and token tracking
   18_rails/                   # Minimal Rails 8 demo app (full integration)
     app/robots/chat_robot.rb  #   Robot factory with system prompt + TimeTool
     app/tools/time_tool.rb    #   Custom RobotLab::Tool subclass
@@ -189,6 +190,12 @@ Builds up cross-run observations with `robot.learn(text)`. A code reviewer accum
 Demonstrates `robot.compress_history()` for reducing token usage in long conversations. Old turns are scored against the recent context using stemmed term-frequency cosine similarity (via the `classifier` gem). High-relevance turns are kept verbatim; irrelevant turns are dropped; medium-relevance turns can optionally be summarized by a second robot. Shows both drop-mode and summarizer-lambda patterns, plus the LLM summarizer integration recipe.
 
 **Requires:** `gem 'classifier', '~> 2.3'` in your Gemfile (no LLM calls in the demo itself)
+
+### 24 — Structured Delegation
+
+A manager robot delegates sub-tasks to a summarizer and an analyst. Each `delegate()` call returns a `RobotResult` annotated with `delegated_by`, `duration`, and token counts. Includes a comparison table of when to use delegation vs. bus messaging vs. pipelines.
+
+**Requires:** LLM API key
 
 ### 23 — Debate Convergence Detection
 

--- a/lib/robot_lab/delegation_future.rb
+++ b/lib/robot_lab/delegation_future.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module RobotLab
+  # A promise-like object returned by robot.delegate(async: true).
+  #
+  # The delegated task runs in a background thread. The caller can check
+  # whether the result is ready with +resolved?+ and block until it arrives
+  # with +value+ (or its alias +wait+).
+  #
+  # @example Fan-out to two specialists in parallel
+  #   f1 = manager.delegate(to: summarizer, task: "summarize ...", async: true)
+  #   f2 = manager.delegate(to: analyst,    task: "analyze ...",   async: true)
+  #
+  #   # Other work here while both run in parallel
+  #
+  #   summary  = f1.value           # blocks if not yet done
+  #   analysis = f2.value
+  #
+  # @example With a timeout
+  #   result = future.value(timeout: 10)   # raises DelegationTimeout if too slow
+  #
+  class DelegationFuture
+    # Raised when +value(timeout: N)+ expires before the result arrives.
+    class DelegationTimeout < Error; end
+
+    # @return [String] name of the robot that was delegated to
+    attr_reader :robot_name
+
+    # @return [String] name of the robot that created this future
+    attr_reader :delegated_by
+
+    # @param robot_name [String]
+    # @param delegated_by [String]
+    def initialize(robot_name:, delegated_by:)
+      @robot_name   = robot_name
+      @delegated_by = delegated_by
+      @mutex        = Mutex.new
+      @cv           = ConditionVariable.new
+      @result       = nil
+      @error        = nil
+      @resolved     = false
+    end
+
+    # True once the delegated task has completed (successfully or with an error).
+    #
+    # @return [Boolean]
+    def resolved?
+      @mutex.synchronize { @resolved }
+    end
+
+    # Block until the result is available and return it.
+    #
+    # @param timeout [Numeric, nil] maximum seconds to wait; nil means wait forever
+    # @return [RobotResult]
+    # @raise [DelegationTimeout] if +timeout+ is given and expires
+    # @raise [StandardError] re-raises any error thrown by the delegated task
+    def value(timeout: nil)
+      @mutex.synchronize do
+        unless @resolved
+          @cv.wait(@mutex, timeout)
+        end
+
+        unless @resolved
+          raise DelegationTimeout,
+                "Delegation to '#{@robot_name}' timed out after #{timeout}s"
+        end
+
+        raise @error if @error
+
+        @result
+      end
+    end
+    alias_method :wait, :value
+
+    # @api private — called by Robot#delegate from the worker thread
+    def resolve!(result)
+      @mutex.synchronize do
+        @result   = result
+        @resolved = true
+        @cv.broadcast
+      end
+    end
+
+    # @api private — called by Robot#delegate from the worker thread on error
+    def reject!(error)
+      @mutex.synchronize do
+        @error    = error
+        @resolved = true
+        @cv.broadcast
+      end
+    end
+  end
+end

--- a/lib/robot_lab/memory.rb
+++ b/lib/robot_lab/memory.rb
@@ -112,6 +112,12 @@ module RobotLab
       @waiters = Hash.new { |h, k| h[k] = [] }
       @subscription_mutex = Mutex.new
       @waiter_mutex = Mutex.new
+
+      # Notification coalescing — batches multiple key changes into a single
+      # drainer fiber rather than spawning one Async task per callback per change.
+      @notification_queue       = []
+      @notification_queue_mutex = Mutex.new
+      @drainer_scheduled        = false
     end
 
     # Get value by key
@@ -758,10 +764,8 @@ module RobotLab
       callbacks = []
 
       @subscription_mutex.synchronize do
-        # Exact key matches
         callbacks.concat(@subscriptions[key].map { |s| s[:callback] })
 
-        # Pattern matches
         key_str = key.to_s
         @pattern_subscriptions.each do |sub|
           callbacks << sub[:callback] if sub[:pattern].match?(key_str)
@@ -770,7 +774,6 @@ module RobotLab
 
       return if callbacks.empty?
 
-      # Build the change object
       change = MemoryChange.new(
         key: key,
         value: value,
@@ -780,10 +783,44 @@ module RobotLab
         timestamp: Time.now
       )
 
-      # Dispatch callbacks asynchronously
-      callbacks.each do |callback|
-        dispatch_async { callback.call(change) }
+      # Coalesce: push onto the batch queue and spawn at most one drainer fiber.
+      # Under rapid writes (e.g. many network robots writing simultaneously) this
+      # reduces Async fiber churn from O(subscribers × key_changes) to O(1).
+      schedule_drain = false
+      @notification_queue_mutex.synchronize do
+        @notification_queue << { change: change, callbacks: callbacks }
+        unless @drainer_scheduled
+          @drainer_scheduled = true
+          schedule_drain = true
+        end
       end
+
+      dispatch_async { drain_notification_queue } if schedule_drain
+    end
+
+    # Drain all pending notification batches in a single fiber.
+    # Loops until the queue is empty, then resets the drainer flag.
+    # If new items arrive just before the flag resets, reschedules itself.
+    def drain_notification_queue
+      loop do
+        batch = @notification_queue_mutex.synchronize do
+          items = @notification_queue.dup
+          @notification_queue.clear
+          items
+        end
+
+        break if batch.empty?
+
+        batch.each do |item|
+          item[:callbacks].each { |cb| cb.call(item[:change]) }
+        end
+      end
+    ensure
+      reschedule = @notification_queue_mutex.synchronize do
+        @drainer_scheduled = false
+        !@notification_queue.empty?
+      end
+      dispatch_async { drain_notification_queue } if reschedule
     end
 
     def generate_subscription_id

--- a/lib/robot_lab/robot.rb
+++ b/lib/robot_lab/robot.rb
@@ -543,6 +543,59 @@ module RobotLab
       replace_messages(compressed)
     end
 
+    # Delegate a task to another robot, synchronously or asynchronously.
+    #
+    # **Synchronous** (default, +async: false+): blocks until the delegatee
+    # finishes and returns a +RobotResult+ annotated with +delegated_by+,
+    # +duration+, and token counts.
+    #
+    # **Asynchronous** (+async: true+): starts the delegatee in a background
+    # thread and returns a +DelegationFuture+ immediately. Call +future.value+
+    # to block for the result, or +future.resolved?+ to poll.
+    #
+    # @example Synchronous
+    #   result = manager.delegate(to: analyst, task: "What are the risks?")
+    #   puts result.reply          # analyst's answer
+    #   puts result.delegated_by   # => "manager"
+    #   puts result.duration       # => 1.43 (seconds)
+    #
+    # @example Async fan-out
+    #   f1 = manager.delegate(to: summarizer, task: "summarize ...", async: true)
+    #   f2 = manager.delegate(to: analyst,    task: "analyze ...",   async: true)
+    #   summary  = f1.value          # blocks if not yet done
+    #   analysis = f2.value(timeout: 30)
+    #
+    # @param to [Robot] the robot to delegate to
+    # @param task [String] the message to send
+    # @param async [Boolean] when true, returns a DelegationFuture immediately
+    # @param kwargs [Hash] additional keyword args forwarded to Robot#run
+    # @return [RobotResult] when async: false
+    # @return [DelegationFuture] when async: true
+    def delegate(to:, task:, async: false, **kwargs)
+      if async
+        future = DelegationFuture.new(robot_name: to.name, delegated_by: @name)
+        delegator_name = @name
+
+        Thread.new do
+          started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          result = to.run(task, **kwargs)
+          result.duration     = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+          result.delegated_by = delegator_name
+          future.resolve!(result)
+        rescue => e
+          future.reject!(e)
+        end
+
+        future
+      else
+        started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        result = to.run(task, **kwargs)
+        result.duration     = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+        result.delegated_by = @name
+        result
+      end
+    end
+
     # Return the provider for this robot's chat.
     # Useful for displaying model/provider info without reaching
     # into chat internals.

--- a/lib/robot_lab/robot_result.rb
+++ b/lib/robot_lab/robot_result.rb
@@ -37,13 +37,15 @@ module RobotLab
 
     # @!attribute [rw] duration
     #   @return [Float, nil] elapsed seconds for this run
+    # @!attribute [rw] delegated_by
+    #   @return [String, nil] name of the robot that delegated this task
     # @!attribute [rw] prompt
     #   @return [Array<Message>, nil] the prompt messages used (debug)
     # @!attribute [rw] history
     #   @return [Array<Message>, nil] the history used (debug)
     # @!attribute [rw] raw
     #   @return [Object, nil] the raw LLM response (debug)
-    attr_accessor :duration, :prompt, :history, :raw
+    attr_accessor :duration, :delegated_by, :prompt, :history, :raw
 
     # Creates a new RobotResult instance.
     #
@@ -109,12 +111,14 @@ module RobotLab
     def export
       {
         robot_name: robot_name,
+        delegated_by: delegated_by,
         output: output.map(&:to_h),
         tool_calls: tool_calls.map(&:to_h),
         created_at: created_at.iso8601,
         id: id,
         checksum: checksum,
         stop_reason: stop_reason,
+        duration: duration,
         input_tokens: input_tokens.positive? ? input_tokens : nil,
         output_tokens: output_tokens.positive? ? output_tokens : nil
       }.compact

--- a/test/robot_lab/memory_test.rb
+++ b/test/robot_lab/memory_test.rb
@@ -904,6 +904,61 @@ class RobotLab::MemoryTest < Minitest::Test
     refute_nil change.timestamp
   end
 
+  # =========================================================================
+  # Notification coalescing
+  # =========================================================================
+
+  def test_single_subscriber_receives_notification
+    received = []
+    @memory.subscribe(:alpha) { |change| received << change.value }
+    @memory[:alpha] = "hello"
+    wait_until(timeout: 1) { received.size == 1 }
+    assert_equal ["hello"], received
+  end
+
+  def test_multiple_subscribers_same_key_all_notified
+    a = []
+    b = []
+    @memory.subscribe(:beta) { |change| a << change.value }
+    @memory.subscribe(:beta) { |change| b << change.value }
+    @memory[:beta] = 42
+    wait_until(timeout: 1) { a.size == 1 && b.size == 1 }
+    assert_equal [42], a
+    assert_equal [42], b
+  end
+
+  def test_rapid_writes_all_notifications_delivered
+    received = []
+    @memory.subscribe(:counter) { |change| received << change.value }
+    5.times { |i| @memory[:counter] = i }
+    wait_until(timeout: 2) { received.size == 5 }
+    assert_equal 5, received.size
+    assert_equal (0..4).to_a, received.sort
+  end
+
+  def test_notifications_from_different_keys_all_delivered
+    results = Hash.new { |h, k| h[k] = [] }
+    @memory.subscribe(:x) { |change| results[:x] << change.value }
+    @memory.subscribe(:y) { |change| results[:y] << change.value }
+    @memory[:x] = "ex"
+    @memory[:y] = "why"
+    wait_until(timeout: 1) { results[:x].size == 1 && results[:y].size == 1 }
+    assert_equal ["ex"],  results[:x]
+    assert_equal ["why"], results[:y]
+  end
+
+  def test_coalescing_drainer_resets_after_drain
+    received = []
+    @memory.subscribe(:tap) { |change| received << change.value }
+    @memory[:tap] = "first"
+    wait_until(timeout: 1) { received.size == 1 }
+
+    # Second write after drainer has finished — must still be delivered
+    @memory[:tap] = "second"
+    wait_until(timeout: 1) { received.size == 2 }
+    assert_equal %w[first second], received
+  end
+
   private
 
   def mock_robot_result(robot_name)

--- a/test/robot_lab/robot_test.rb
+++ b/test/robot_lab/robot_test.rb
@@ -2339,4 +2339,211 @@ class RobotLab::RobotTest < Minitest::Test
     assert_equal 1, replies.size
     assert_equal "LLM reply from bob", replies.first.content
   end
+
+  # =========================================================================
+  # Structured Delegation
+  # =========================================================================
+
+  def fake_response_for(robot, content)
+    resp = Data.define(:content, :tool_calls, :stop_reason, :tokens).new(
+      content: content, tool_calls: nil, stop_reason: "end_turn", tokens: nil
+    )
+    chat = robot.instance_variable_get(:@chat)
+    chat.define_singleton_method(:ask) { |_msg = nil, **_kw, &_b| resp }
+    resp
+  end
+
+  def test_delegate_returns_robot_result
+    delegator = build_robot(name: "manager", template: :assistant)
+    worker    = build_robot(name: "worker",  template: :assistant)
+    fake_response_for(worker, "task done")
+
+    result = delegator.delegate(to: worker, task: "do the thing")
+
+    assert_kind_of RobotLab::RobotResult, result
+    assert_equal "task done", result.reply
+  end
+
+  def test_delegate_sets_delegated_by
+    delegator = build_robot(name: "manager", template: :assistant)
+    worker    = build_robot(name: "worker",  template: :assistant)
+    fake_response_for(worker, "done")
+
+    result = delegator.delegate(to: worker, task: "summarize")
+
+    assert_equal "manager", result.delegated_by
+  end
+
+  def test_delegate_sets_robot_name_to_delegatee
+    delegator = build_robot(name: "manager", template: :assistant)
+    worker    = build_robot(name: "specialist", template: :assistant)
+    fake_response_for(worker, "analysis complete")
+
+    result = delegator.delegate(to: worker, task: "analyze")
+
+    assert_equal "specialist", result.robot_name
+  end
+
+  def test_delegate_records_duration
+    delegator = build_robot(name: "manager", template: :assistant)
+    worker    = build_robot(name: "worker",  template: :assistant)
+    fake_response_for(worker, "done")
+
+    result = delegator.delegate(to: worker, task: "work")
+
+    assert_kind_of Float, result.duration
+    assert_operator result.duration, :>=, 0.0
+  end
+
+  def test_delegate_forwards_kwargs_to_run
+    delegator = build_robot(name: "manager",  template: :assistant)
+    worker    = build_robot(name: "templated", template: :parameterized_main_test)
+
+    received = nil
+    resp = Data.define(:content, :tool_calls, :stop_reason, :tokens).new(
+      content: "ok", tool_calls: nil, stop_reason: "end_turn", tokens: nil
+    )
+    worker_chat = worker.instance_variable_get(:@chat)
+    worker_chat.define_singleton_method(:ask) { |msg = nil, **_kw, &_b| received = msg; resp }
+
+    delegator.delegate(to: worker, task: "hello", company_name: "Acme")
+
+    refute_nil received
+  end
+
+  def test_delegated_by_nil_on_direct_run
+    robot = build_robot(name: "solo", template: :assistant)
+    fake_response_for(robot, "direct")
+
+    result = robot.run("question")
+
+    assert_nil result.delegated_by
+  end
+
+  # -----------------------------------------------------------------------
+  # Async delegation
+  # -----------------------------------------------------------------------
+
+  def test_async_delegate_returns_delegation_future
+    delegator = build_robot(name: "manager",  template: :assistant)
+    worker    = build_robot(name: "worker",   template: :assistant)
+    fake_response_for(worker, "async done")
+
+    future = delegator.delegate(to: worker, task: "work", async: true)
+
+    assert_kind_of RobotLab::DelegationFuture, future
+  end
+
+  def test_async_delegate_future_resolves_with_result
+    delegator = build_robot(name: "manager", template: :assistant)
+    worker    = build_robot(name: "worker",  template: :assistant)
+    fake_response_for(worker, "async answer")
+
+    future = delegator.delegate(to: worker, task: "async task", async: true)
+    result = future.value(timeout: 5)
+
+    assert_kind_of RobotLab::RobotResult, result
+    assert_equal "async answer", result.reply
+  end
+
+  def test_async_delegate_sets_delegated_by
+    delegator = build_robot(name: "manager", template: :assistant)
+    worker    = build_robot(name: "worker",  template: :assistant)
+    fake_response_for(worker, "done")
+
+    future = delegator.delegate(to: worker, task: "task", async: true)
+    result = future.value(timeout: 5)
+
+    assert_equal "manager", result.delegated_by
+  end
+
+  def test_async_delegate_sets_robot_name
+    delegator = build_robot(name: "manager",    template: :assistant)
+    worker    = build_robot(name: "specialist", template: :assistant)
+    fake_response_for(worker, "done")
+
+    future = delegator.delegate(to: worker, task: "task", async: true)
+    result = future.value(timeout: 5)
+
+    assert_equal "specialist", result.robot_name
+  end
+
+  def test_async_delegate_records_duration
+    delegator = build_robot(name: "manager", template: :assistant)
+    worker    = build_robot(name: "worker",  template: :assistant)
+    fake_response_for(worker, "done")
+
+    future = delegator.delegate(to: worker, task: "task", async: true)
+    result = future.value(timeout: 5)
+
+    assert_kind_of Float, result.duration
+    assert_operator result.duration, :>=, 0.0
+  end
+
+  def test_async_delegate_future_resolved_predicate
+    delegator = build_robot(name: "manager", template: :assistant)
+    worker    = build_robot(name: "worker",  template: :assistant)
+    fake_response_for(worker, "done")
+
+    future = delegator.delegate(to: worker, task: "task", async: true)
+
+    refute future.resolved?  # likely not done yet
+    future.value(timeout: 5)
+    assert future.resolved?
+  end
+
+  def test_async_delegate_future_carries_robot_name_before_resolution
+    delegator = build_robot(name: "manager",    template: :assistant)
+    worker    = build_robot(name: "specialist", template: :assistant)
+
+    # Don't stub — future is checked before it resolves
+    future = delegator.delegate(to: worker, task: "task", async: true)
+
+    assert_equal "specialist", future.robot_name
+    assert_equal "manager",    future.delegated_by
+  end
+
+  def test_async_delegate_fan_out_two_specialists
+    delegator   = build_robot(name: "manager",    template: :assistant)
+    summarizer  = build_robot(name: "summarizer", template: :assistant)
+    analyst     = build_robot(name: "analyst",    template: :assistant)
+
+    fake_response_for(summarizer, "brief summary")
+    fake_response_for(analyst,    "key metric")
+
+    f1 = delegator.delegate(to: summarizer, task: "summarize", async: true)
+    f2 = delegator.delegate(to: analyst,    task: "analyze",   async: true)
+
+    r1 = f1.value(timeout: 5)
+    r2 = f2.value(timeout: 5)
+
+    assert_equal "brief summary", r1.reply
+    assert_equal "key metric",    r2.reply
+    assert_equal "manager", r1.delegated_by
+    assert_equal "manager", r2.delegated_by
+  end
+
+  def test_async_delegate_future_rejects_on_error
+    delegator = build_robot(name: "manager", template: :assistant)
+    worker    = build_robot(name: "worker",  template: :assistant)
+
+    worker_chat = worker.instance_variable_get(:@chat)
+    worker_chat.define_singleton_method(:ask) { |_msg = nil, **_kw, &_b| raise RuntimeError, "boom" }
+
+    future = delegator.delegate(to: worker, task: "task", async: true)
+
+    assert_raises(RuntimeError) { future.value(timeout: 5) }
+  end
+
+  def test_async_delegate_future_timeout_raises_delegation_timeout
+    delegator = build_robot(name: "manager", template: :assistant)
+    worker    = build_robot(name: "worker",  template: :assistant)
+
+    worker_chat = worker.instance_variable_get(:@chat)
+    worker_chat.define_singleton_method(:ask) { |_msg = nil, **_kw, &_b| sleep 10 }
+
+    future = delegator.delegate(to: worker, task: "task", async: true)
+
+    assert_raises(RobotLab::DelegationFuture::DelegationTimeout) { future.value(timeout: 0.05) }
+  end
 end


### PR DESCRIPTION
## Summary

- **`robot.delegate(to:, task:)`** — synchronous inter-robot call; returns a `RobotResult` annotated with `delegated_by`, `duration`, and token counts
- **`robot.delegate(to:, task:, async: true)`** — fires the delegatee in a background thread and returns a `DelegationFuture` immediately, enabling parallel fan-out patterns
- **`DelegationFuture`** — promise-like object with `value(timeout:)`, `resolved?`, `robot_name`, and `delegated_by`; re-raises worker errors; raises `DelegationFuture::DelegationTimeout` on expiry
- **Memory notification coalescing** — `notify_subscribers_async` now batches all callbacks into a `@notification_queue` and drains via a single Async fiber instead of spawning O(subscribers × key_changes) fibers; race-safe drainer reschedules itself if new items arrive during the final window

## New files

| File | Purpose |
|---|---|
| `lib/robot_lab/delegation_future.rb` | Thread-backed promise with timeout and error propagation |
| `examples/24_structured_delegation.rb` | Sync + async fan-out demo with real LLM calls and wall-time comparison |

## Modified files

| File | Change |
|---|---|
| `lib/robot_lab/robot.rb` | Added `delegate(to:, task:, async: false, **kwargs)` |
| `lib/robot_lab/robot_result.rb` | Added `delegated_by` attr; `duration` and `delegated_by` included in `export`/`to_h` |
| `lib/robot_lab/memory.rb` | Notification coalescing: queue + single drainer fiber |
| `test/robot_lab/robot_test.rb` | 16 new delegation tests (sync + async, fan-out, timeout, error rejection) |
| `test/robot_lab/memory_test.rb` | 5 new coalescing tests (single/multi subscriber, rapid writes, cross-key, drainer reset) |

## Test plan

- [ ] `bundle exec rake test` — 1013 runs, 0 failures, 0 errors, 0 skips
- [ ] `ruby examples/24_structured_delegation.rb` — sync section shows sequential calls; async section fires two requests 1ms apart, total wall time ≈ slower of the two (not sum)

## Async fan-out observed output

```
Firing both delegations in parallel...
Both futures launched. Futures resolved? summary=false analysis=false
Total wall time with parallelism: 2.47s (vs ~3.90s sequential)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)