### PR TITLE
feat(ractor-parallelism): add new Ractor-based parallelism features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.12] - 2026-04-18
+
+### Added
+
+- **README: Context Window Compression section** — documents `robot.compress_history` with threshold tuning (`recent_turns`, `keep_threshold`, `drop_threshold`) and summarizer lambda pattern
+- **README: Convergence Detection section** — documents `RobotLab::Convergence.detected?` / `.similarity` with network router fast-path example
+- **README: Structured Delegation section** — documents `robot.delegate(to:, task:)` sync and async modes, `DelegationFuture` fan-out pattern, and timeout handling
+- **README: Ractor Parallelism section** — documents `ractor_safe true` tool macro and `parallel_mode: :ractor` network mode with link to full guide
+- **`docs/guides/building-robots.md`** — added matching sections for all four features above with expanded API detail, `DelegationFuture` method table, and convergence router example
+- **`docs/api/core/result.md`** — new API reference for `RobotResult`: attributes, token tracking, delegation metadata, persistence (`export`, `from_hash`, `checksum`), and debug fields
+- **`docs/api/errors.md`** — new error hierarchy reference covering all `RobotLab::Error` subclasses (`ConfigurationError`, `DependencyError`, `InferenceError`, `ToolLoopError`, `ToolNotFoundError`, `MCPError`, `BusError`, `RactorBoundaryError`, `ToolError`, `DelegationFuture::DelegationTimeout`) with rescue examples
+
+### Changed
+
+- Bumped version to 0.0.12
+- Updated `bigdecimal` to 4.1.2
+- Updated `protocol-http` to 0.62.2
+- Updated `protocol-websocket` to 0.21.0
+- Updated `rake` to 13.4.2
+- Updated `sqlite3` to 2.9.3
+
 ## [0.0.11] - 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11] - 2026-04-14
+
+### Added
+
+- **Ractor parallelism — Track 1: CPU-bound tools** (`RactorWorkerPool`)
+  - `ractor_safe true` class macro on `Tool` — opts a tool class into Ractor execution; subclasses inherit automatically
+  - `RobotLab.ractor_pool` — global `RactorWorkerPool` singleton, one Ractor worker per CPU core by default
+  - `ractor_pool_size` field on `RunConfig` for configuring pool capacity
+  - `RactorWorkerPool#submit(tool_name, args)` — submits a job and blocks for the frozen result; raises `ToolError` on failure
+  - Tool dispatch routes `ractor_safe` tools through the pool automatically, bypassing the GVL for CPU-intensive work
+  - `RactorBoundary.freeze_deep(obj)` — deep-freezes nested hashes/arrays/strings to make them Ractor-shareable; raises `RactorBoundaryError` for non-shareable objects (Procs, IOs, etc.)
+- **Ractor parallelism — Track 2: parallel robot pipelines** (`RactorNetworkScheduler`)
+  - `parallel_mode: :ractor` on `Network.new` — routes `network.run` through `RactorNetworkScheduler` instead of `SimpleFlow::Pipeline`
+  - `RactorNetworkScheduler` dispatches dependency waves: independent tasks run concurrently (one Thread per task); dependent tasks wait for their wave to complete
+  - `RobotSpec` — frozen `Data.define` descriptor carrying robot name, template, system prompt, and config; safely crosses Ractor boundaries
+  - `RactorNetworkScheduler#run_pipeline` returns `Hash { robot_name => result_string }` for the full pipeline
+  - `RactorNetworkScheduler#run_spec` for single-spec dispatch
+  - `RactorNetworkScheduler#shutdown` for graceful poison-pill cleanup
+  - `network.parallel_mode` reader exposes the configured mode (default `:async`)
+- **Ractor memory proxy** — `RactorMemoryProxy` wraps `Memory` via `ractor-wrapper` for safe cross-Ractor memory access
+- **Infrastructure data classes** — `RactorJob`, `RactorJobError` (`Data.define` structs) for job submission and error propagation across Ractor boundaries
+- **`RactorBoundaryError`** — raised by `freeze_deep` when a non-shareable value (Proc, IO, etc.) would cross a Ractor boundary
+- **`ToolError`** — raised by `RactorWorkerPool#submit` when a tool raises inside a Ractor; propagates message and frozen backtrace
+- **Dependencies** — `ractor_queue` (~> 0.1) and `ractor-wrapper` (~> 0.4) added to gemspec
+- **Ractor Parallelism guide** (`docs/guides/ractor-parallelism.md`) — covers architecture, two-track design, configuration, error handling, constraints, and best practices
+- **Example 29: Ractor-Safe CPU Tools** (`examples/29_ractor_tools.rb`) — demonstrates `ractor_safe` flag, inheritance, `freeze_deep`, pool submissions, `ToolError` propagation, and parallel batch timing; no API key required
+- **Example 30: Ractor Network Scheduler** (`examples/30_ractor_network.rb`) — demonstrates `RactorNetworkScheduler` wave ordering with simulated latencies, `Network.new(parallel_mode: :ractor)` API, and dependency graph inspection; no API key required for Parts 1 & 2
+
+### Fixed
+
+- `ToolConfig::NONE_VALUES` constant was not Ractor-shareable because its inner empty array `[]` was mutable; fixed by replacing `[]` with `[].freeze` so the entire constant is deeply frozen and safe to read from any Ractor
+
 ## [0.0.9] - 2026-03-02
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    robot_lab (0.0.11)
+    robot_lab (0.0.12)
       async (~> 2.0)
       async-http (~> 0.60)
       async-websocket (~> 0.30)
@@ -90,7 +90,7 @@ GEM
       protocol-rack (~> 0.7)
       protocol-websocket (~> 0.17)
     base64 (0.3.0)
-    bigdecimal (4.1.1)
+    bigdecimal (4.1.2)
     builder (3.3.0)
     classifier (2.3.2)
       fast-stemmer (~> 1.0)
@@ -204,7 +204,7 @@ GEM
     prompt_manager (1.0.2)
       ostruct
     protocol-hpack (1.5.1)
-    protocol-http (0.62.0)
+    protocol-http (0.62.2)
     protocol-http1 (0.39.0)
       protocol-http (~> 0.62)
     protocol-http2 (0.26.0)
@@ -215,7 +215,7 @@ GEM
       protocol-http (~> 0.58)
       rack (>= 1.0)
     protocol-url (0.4.0)
-    protocol-websocket (0.20.2)
+    protocol-websocket (0.21.0)
       protocol-http (~> 0.2)
     psych (5.3.1)
       date
@@ -250,7 +250,7 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.4.1)
+    rake (13.4.2)
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -304,8 +304,8 @@ GEM
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     simpleidn (0.2.3)
-    sqlite3 (2.9.2-arm64-darwin)
-    sqlite3 (2.9.2-x86_64-linux-gnu)
+    sqlite3 (2.9.3-arm64-darwin)
+    sqlite3 (2.9.3-x86_64-linux-gnu)
     state_machines (0.101.0)
     state_machines-activemodel (0.102.0)
       activemodel (>= 7.2)
@@ -382,7 +382,7 @@ CHECKSUMS
   async-pool (0.11.2) sha256=0a43a17b02b04d9c451b7d12fafa9a50e55dc6dd00d4369aca00433f16a7e3ed
   async-websocket (0.30.0) sha256=55739954528ad8f87f7792d0452e1268d1ef2aa5b3719f79400a05a1a6202cdf
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
-  bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   classifier (2.3.2) sha256=f94c28e5d129a54939e6f828f18f8579a94dcf18b006df44e5790c9f15185620
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
@@ -447,12 +447,12 @@ CHECKSUMS
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   prompt_manager (1.0.2) sha256=ec19631fc90d092df1d7d08aa3d523636f55a3725b90635afc1fae7d60609e31
   protocol-hpack (1.5.1) sha256=6feca238b8078da1cd295677d6f306c6001af92d75fe0643d33e6956cbc3ad91
-  protocol-http (0.62.0) sha256=2b7a84a83c7d7c9ca1edfa3a31edcdb91a9264af86c2cb905b486091b35b461a
+  protocol-http (0.62.2) sha256=e1c1f2f56029c1af8c4e2b8a67d0d096c76620f3afd8d99d1dcd2f6b8ffa773b
   protocol-http1 (0.39.0) sha256=e49b3f4cda6f5d94c76a323d2b7f6977cba3ebd082d2da437039594da77ad8eb
   protocol-http2 (0.26.0) sha256=bac89cd78082b241ccd0cf7246f5160e4bb0c9c975fb4bf7deef5f88cc317486
   protocol-rack (0.22.1) sha256=1185d245927ef9849a603700d6991ca353bc89724fbf98efa4a4333ed62a9fc3
   protocol-url (0.4.0) sha256=64d4c03b6b51ad815ac6fdaf77a1d91e5baf9220d26becb846c5459dacdea9e1
-  protocol-websocket (0.20.2) sha256=c41d93c35fba5dae85375c597f76975f3dbd75d8c5b2f21b33dab4dc22a5a511
+  protocol-websocket (0.21.0) sha256=6e2ccc2adf7de1895b0f6548fdfacf5f9735c0d4deb56cd2bac1ae38a1952e93
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
@@ -466,13 +466,13 @@ CHECKSUMS
   rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
-  rake (13.4.1) sha256=b4e81bd6a748308a6799619d824ec6a23cd1acd07d9ec41e5f2ebfb2294447c8
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rice (4.11.5) sha256=8eddb1b297e90a221a65e56fc07f27065457b21db0f508dd0561ad86a048f620
-  robot_lab (0.0.11)
+  robot_lab (0.0.12)
   rubocop (1.86.1) sha256=44415f3f01d01a21e01132248d2fd0867572475b566ca188a0a42133a08d4531
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   ruby-next-core (1.2.0) sha256=f6a7d00bb5186cecbb02f7f1845a0f3a2c9788d35b6ccff5c9be3f0d46799b86
@@ -487,8 +487,8 @@ CHECKSUMS
   simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
-  sqlite3 (2.9.2-arm64-darwin) sha256=d15bd9609a05f9d54930babe039585efc8cadd57517c15b64ec7dfa75158a5e9
-  sqlite3 (2.9.2-x86_64-linux-gnu) sha256=dce83ffcb7e72f9f7aeb6e5404f15d277a45332fe18ccce8a8b3ed51e8d23aee
+  sqlite3 (2.9.3-arm64-darwin) sha256=76b265d3d57362d3e38338f24f50a0c9cd47a4599c9cfbb578fac125d2299906
+  sqlite3 (2.9.3-x86_64-linux-gnu) sha256=85200a10c6cf5c60085fcca411a3168c5fba8fda3e2b1b0109ec277d7c226d46
   state_machines (0.101.0) sha256=cbcec89699a0388493226a4b18d790bd5d49c38ba782d2099342a3dd78bcbca3
   state_machines-activemodel (0.102.0) sha256=871ac36194227c17f61053c3cfe61606f0a23e62e3ec8715f61fc6a3f94ba274
   state_machines-activerecord (0.103.0) sha256=7c774b5a47a0de8496130e7e69e6f959d3e2b1f1b7e682c24f95bfa670b5b3cc
@@ -510,4 +510,4 @@ CHECKSUMS
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
 
 BUNDLED WITH
-  4.0.6
+  4.0.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    robot_lab (0.0.10)
+    robot_lab (0.0.11)
       async (~> 2.0)
       async-http (~> 0.60)
       async-websocket (~> 0.30)
@@ -472,7 +472,7 @@ CHECKSUMS
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rice (4.11.5) sha256=8eddb1b297e90a221a65e56fc07f27065457b21db0f508dd0561ad86a048f620
-  robot_lab (0.0.10)
+  robot_lab (0.0.11)
   rubocop (1.86.1) sha256=44415f3f01d01a21e01132248d2fd0867572475b566ca188a0a42133a08d4531
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   ruby-next-core (1.2.0) sha256=f6a7d00bb5186cecbb02f7f1845a0f3a2c9788d35b6ccff5c9be3f0d46799b86

--- a/README.md
+++ b/README.md
@@ -700,6 +700,136 @@ reviewer.learnings          # => ["This codebase prefers map/collect..."]
 reviewer.learn("new fact")  # deduplicates before storing
 ```
 
+## Context Window Compression
+
+`robot.compress_history` prunes old conversation turns using TF-IDF cosine similarity, keeping only turns that are relevant to the most recent context. System messages and tool call/result pairs are always preserved.
+
+```ruby
+# Basic compression: protect the 3 most recent turns, drop unrelated old turns
+robot.compress_history
+
+# Tune the thresholds
+robot.compress_history(
+  recent_turns:   5,    # protect this many recent user+assistant pairs
+  keep_threshold: 0.6,  # turns scoring >= this are kept verbatim
+  drop_threshold: 0.2   # turns scoring < this are dropped
+)
+
+# Summarize medium-relevance turns instead of dropping them
+summarizer_bot = RobotLab.build(name: "summarizer", system_prompt: "Summarize concisely.")
+robot.compress_history(
+  summarizer: ->(text) { summarizer_bot.run("One sentence: #{text}").reply }
+)
+```
+
+Requires the optional `classifier` gem (`~> 2.3`). Add it to your Gemfile:
+
+```ruby
+gem "classifier", "~> 2.3"
+```
+
+## Convergence Detection
+
+`RobotLab::Convergence` detects when two independent agents have reached the same conclusion using TF-IDF cosine similarity. Use it as a router fast-path to skip an expensive reconciler LLM call when verifiers already agree.
+
+```ruby
+# Check similarity directly
+score = RobotLab::Convergence.similarity(result_a.reply, result_b.reply)
+# => 0.92
+
+# Boolean check against a threshold (default: 0.85)
+RobotLab::Convergence.detected?(result_a.reply, result_b.reply)
+# => true
+
+# Use a custom threshold
+RobotLab::Convergence.detected?(text_a, text_b, threshold: 0.75)
+```
+
+A common pattern is wiring convergence into a network router to skip reconciliation:
+
+```ruby
+router = ->(args) do
+  a = args.context[:verifier_a]&.reply.to_s
+  b = args.context[:verifier_b]&.reply.to_s
+  RobotLab::Convergence.detected?(a, b) ? nil : ["reconciler"]
+end
+
+network = RobotLab.create_network(name: "verify", router: router) do
+  # ...
+end
+```
+
+Requires the `classifier` gem (`~> 2.3`).
+
+## Structured Delegation
+
+`robot.delegate(to:, task:)` dispatches work to another robot and returns the result, with duration and token metadata attached. Pass `async: true` for non-blocking fan-out.
+
+```ruby
+analyst  = RobotLab.build(name: "analyst",  system_prompt: "Analyze data.")
+writer   = RobotLab.build(name: "writer",   system_prompt: "Write reports.")
+manager  = RobotLab.build(name: "manager",  system_prompt: "Coordinate work.")
+
+# Synchronous delegation — blocks until done
+result = manager.delegate(to: analyst, task: "Analyze Q3 sales data")
+puts result.reply
+puts "%.2fs, %d tokens" % [result.duration, result.output_tokens]
+
+# Asynchronous fan-out — returns immediately
+f1 = manager.delegate(to: analyst, task: "Analyze Q3 sales", async: true)
+f2 = manager.delegate(to: writer,  task: "Draft Q3 summary", async: true)
+
+# Do other work here while both run in parallel...
+
+analysis = f1.value           # blocks until resolved
+summary  = f2.value           # blocks until resolved
+
+# With a timeout
+result = f1.value(timeout: 30)  # raises DelegationFuture::DelegationTimeout if too slow
+```
+
+`DelegationFuture` attributes:
+
+```ruby
+future.resolved?      # => true/false (non-blocking poll)
+future.robot_name     # => "analyst"
+future.delegated_by   # => "manager"
+```
+
+## Ractor Parallelism
+
+RobotLab supports true CPU parallelism via Ruby Ractors — isolated execution contexts that bypass the GVL. Two modes are available:
+
+**CPU-bound tools** — mark a tool `ractor_safe true` and RobotLab automatically routes its calls through a global `RactorWorkerPool` instead of running inline:
+
+```ruby
+class TranscribeAudio < RubyLLM::Tool
+  ractor_safe true
+  description "Transcribe an audio file"
+  param :path, type: :string, desc: "Path to audio file"
+
+  def execute(path:)
+    AudioTranscriber.run(path)  # pure computation, no shared mutable state
+  end
+end
+```
+
+**Parallel robot networks** — pass `parallel_mode: :ractor` when creating a network to dispatch independent robots across hardware threads simultaneously:
+
+```ruby
+network = RobotLab.create_network(name: "analysis", parallel_mode: :ractor) do
+  task :fetch,     fetcher_robot,    depends_on: :none
+  task :sentiment, sentiment_robot,  depends_on: [:fetch]
+  task :entities,  entity_robot,     depends_on: [:fetch]   # runs in parallel with sentiment
+  task :summarize, summary_robot,    depends_on: [:sentiment, :entities]
+end
+
+results = network.run(message: "Analyze customer feedback")
+# => { "fetch" => "...", "sentiment" => "positive", "entities" => "...", "summarize" => "..." }
+```
+
+See the [Ractor Parallelism guide](https://madbomber.github.io/robot_lab/guides/ractor-parallelism) for constraints, the frozen-data contract, and `RactorMemoryProxy` for shared state.
+
 ## Rails Integration
 
 ```bash

--- a/docs/api/core/result.md
+++ b/docs/api/core/result.md
@@ -1,0 +1,123 @@
+# RobotResult
+
+`RobotResult` is returned by every `robot.run()` call. It carries the LLM output, tool call results, token usage, timing, and delegation metadata for that execution.
+
+## Accessing the Response
+
+```ruby
+result = robot.run("What is the capital of France?")
+
+result.reply              # => "The capital of France is Paris."
+result.last_text_content  # => alias for reply
+result.output             # => Array of Message objects (full turn)
+result.tool_calls         # => Array of ToolResultMessage objects
+```
+
+`reply` / `last_text_content` returns the content of the last text message in `output`. This is the string you want for the vast majority of use cases.
+
+## Token & Cost Tracking
+
+```ruby
+result.input_tokens   # => Integer — tokens sent to the LLM this run
+result.output_tokens  # => Integer — tokens generated this run
+```
+
+Token counts are zero for providers that do not return usage data.
+
+## Timing
+
+`duration` is set when the result travels through a network pipeline or a `delegate` call. It is `nil` when calling `robot.run()` directly.
+
+```ruby
+result.duration  # => Float (elapsed seconds) or nil
+```
+
+## Delegation Metadata
+
+When a result comes back through `robot.delegate(to:, task:)`, two additional fields are populated:
+
+```ruby
+result.delegated_by  # => "manager"  (the robot that issued the delegation)
+result.duration      # => 2.34       (always set by delegate)
+```
+
+## Identity & Status
+
+```ruby
+result.robot_name   # => "analyst"
+result.id           # => "550e8400-e29b-..."  (UUID, unique per run)
+result.created_at   # => Time instance
+result.stop_reason  # => "end_turn", "tool_use", or nil
+```
+
+## Inspecting the Full Output
+
+```ruby
+result.output.each do |message|
+  puts message.role     # :assistant, :tool, etc.
+  puts message.content  # String or Array
+end
+
+result.has_tool_calls?  # => true if the LLM called any tools
+result.stopped?         # => true if execution ended naturally (not mid-tool-call)
+```
+
+## Persistence
+
+Export for serialization (excludes debug fields):
+
+```ruby
+hash = result.export
+# {
+#   robot_name: "analyst",
+#   output: [...],
+#   tool_calls: [...],
+#   created_at: "2026-04-18T12:00:00Z",
+#   id: "550e8400-...",
+#   checksum: "a1b2c3...",
+#   stop_reason: "end_turn",
+#   duration: 2.34,
+#   input_tokens: 512,
+#   output_tokens: 128
+# }
+
+json = result.to_json
+
+# Reconstruct from hash
+restored = RobotLab::RobotResult.from_hash(hash)
+```
+
+`checksum` is a SHA-256 digest of `output + tool_calls + created_at`. Use it for deduplication when persisting results.
+
+## Debug Fields
+
+These are `nil` by default and only populated when explicitly set for debugging:
+
+```ruby
+result.prompt   # Array<Message> — prompt sent to the LLM
+result.history  # Array<Message> — history used
+result.raw      # raw LLM response object from ruby_llm
+```
+
+## Attribute Reference
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `robot_name` | String | Name of the robot that produced this result |
+| `reply` | String, nil | Last text content (alias: `last_text_content`) |
+| `output` | Array\<Message\> | All output messages from this run |
+| `tool_calls` | Array\<ToolResultMessage\> | Tool call results |
+| `input_tokens` | Integer | Tokens sent to LLM |
+| `output_tokens` | Integer | Tokens generated |
+| `duration` | Float, nil | Elapsed seconds (set by delegate/pipeline) |
+| `delegated_by` | String, nil | Delegating robot's name |
+| `id` | String | UUID |
+| `created_at` | Time | Creation timestamp |
+| `stop_reason` | String, nil | LLM stop reason |
+| `checksum` | String | SHA-256 of output content |
+
+## Related
+
+- [Robot API](robot.md) — `run`, `delegate`, `compress_history`
+- [Building Robots](../../guides/building-robots.md) — Robot construction patterns
+- [Structured Delegation](../../guides/building-robots.md#structured-delegation) — `DelegationFuture` and async fan-out

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -1,0 +1,185 @@
+# Error Reference
+
+All RobotLab exceptions inherit from `RobotLab::Error`, which inherits from `StandardError`. Rescue `RobotLab::Error` to catch any framework exception in one clause, or rescue specific subclasses for targeted handling.
+
+## Hierarchy
+
+```
+StandardError
+└── RobotLab::Error
+    ├── RobotLab::ConfigurationError
+    │   └── RobotLab::DependencyError
+    ├── RobotLab::InferenceError
+    │   └── RobotLab::ToolLoopError
+    ├── RobotLab::ToolNotFoundError
+    ├── RobotLab::MCPError
+    ├── RobotLab::BusError
+    ├── RobotLab::RactorBoundaryError
+    └── RobotLab::ToolError
+```
+
+Additionally, `DelegationFuture` defines its own scoped error:
+
+```
+StandardError
+└── RobotLab::Error
+    └── RobotLab::DelegationFuture::DelegationTimeout
+```
+
+---
+
+## RobotLab::Error
+
+Base class for all RobotLab errors. Rescue this to catch any framework exception.
+
+```ruby
+begin
+  robot.run("hello")
+rescue RobotLab::Error => e
+  puts "RobotLab error: #{e.message}"
+end
+```
+
+---
+
+## RobotLab::ConfigurationError
+
+Raised when configuration is invalid or missing required values.
+
+```ruby
+# Example: missing API key, invalid template path
+rescue RobotLab::ConfigurationError => e
+  puts "Bad config: #{e.message}"
+end
+```
+
+---
+
+## RobotLab::DependencyError < ConfigurationError
+
+Raised when a required optional gem dependency is not installed.
+
+```ruby
+# Triggered by: Convergence, HistoryCompressor when 'classifier' gem is absent
+rescue RobotLab::DependencyError => e
+  puts e.message  # "Add gem 'classifier', '~> 2.3' to your Gemfile"
+end
+```
+
+---
+
+## RobotLab::InferenceError
+
+Raised when LLM inference fails (API errors, timeouts, rate limits).
+
+```ruby
+rescue RobotLab::InferenceError => e
+  puts "LLM call failed: #{e.message}"
+end
+```
+
+---
+
+## RobotLab::ToolLoopError < InferenceError
+
+Raised when a robot's tool call count exceeds `max_tool_rounds:`. The chat history will contain a dangling `tool_use` block with no matching `tool_result`; call `robot.clear_messages` before reusing the robot.
+
+```ruby
+robot = RobotLab.build(
+  name: "runner",
+  system_prompt: "Execute every step.",
+  local_tools: [StepTool],
+  max_tool_rounds: 10
+)
+
+begin
+  robot.run("Run all steps.")
+rescue RobotLab::ToolLoopError => e
+  puts e.message  # "Tool call limit of 10 exceeded"
+  robot.clear_messages  # required before reuse
+end
+```
+
+---
+
+## RobotLab::ToolNotFoundError
+
+Raised when a tool name is referenced but cannot be found in the `ToolManifest`.
+
+---
+
+## RobotLab::MCPError
+
+Raised when MCP server communication fails (connection refused, timeout, protocol error).
+
+```ruby
+rescue RobotLab::MCPError => e
+  puts "MCP failed: #{e.message}"
+end
+```
+
+---
+
+## RobotLab::BusError
+
+Raised when message bus communication fails (no bus configured, channel not found).
+
+```ruby
+rescue RobotLab::BusError => e
+  puts "Bus error: #{e.message}"
+end
+```
+
+---
+
+## RobotLab::RactorBoundaryError
+
+Raised when a value cannot be made Ractor-shareable before crossing a Ractor boundary (e.g., a live `IO` object, a `Proc`, or an object with mutable state).
+
+```ruby
+begin
+  RobotLab::RactorBoundary.freeze_deep({ io: StringIO.new })
+rescue RobotLab::RactorBoundaryError => e
+  puts e.message  # "Cannot make value Ractor-shareable: ..."
+end
+```
+
+Raised proactively by `RactorWorkerPool#submit` and `RactorMemoryProxy#set` before any Ractor is involved.
+
+---
+
+## RobotLab::ToolError
+
+Raised when a tool fails during execution inside a Ractor worker (the pool unwraps `RactorJobError` and re-raises as `ToolError`).
+
+```ruby
+begin
+  pool.submit("MyTool", { input: "bad" })
+rescue RobotLab::ToolError => e
+  puts e.message  # "Tool 'MyTool' failed in Ractor: ..."
+end
+```
+
+---
+
+## RobotLab::DelegationFuture::DelegationTimeout
+
+Raised by `DelegationFuture#value(timeout: N)` when the delegated task does not complete within `N` seconds.
+
+```ruby
+future = manager.delegate(to: analyst, task: "...", async: true)
+
+begin
+  result = future.value(timeout: 10)
+rescue RobotLab::DelegationFuture::DelegationTimeout => e
+  puts e.message  # "Delegation to 'analyst' timed out after 10s"
+end
+```
+
+---
+
+## Related
+
+- [Building Robots](../guides/building-robots.md) — Tool loop circuit breaker, delegation
+- [Ractor Parallelism](../guides/ractor-parallelism.md) — Ractor boundary and tool errors
+- [MCP Integration](../guides/mcp-integration.md) — MCP connection errors

--- a/docs/guides/building-robots.md
+++ b/docs/guides/building-robots.md
@@ -736,6 +736,131 @@ bot = RobotLab.build(name: "latecomer", system_prompt: "Hello.")
 bot.with_bus(existing_bus)  # now connected and can send/receive messages
 ```
 
+## Context Window Compression
+
+Long-running robots accumulate conversation history that can grow to fill the context window. `compress_history` prunes old turns using TF-IDF cosine similarity against the most recent context, keeping turns that are still relevant and discarding or summarizing those that aren't.
+
+```ruby
+# Default settings: protect 3 most-recent turn pairs, drop anything below 0.2
+robot.compress_history
+
+# Tune all thresholds
+robot.compress_history(
+  recent_turns:   5,    # number of recent user+assistant pairs to always keep
+  keep_threshold: 0.6,  # turns with score >= this are kept verbatim (default 0.6)
+  drop_threshold: 0.2   # turns with score < this are dropped (default 0.2)
+)
+```
+
+Medium-relevance turns (between thresholds) are dropped by default. Pass a `summarizer:` callable to replace them with a one-sentence summary instead:
+
+```ruby
+summarizer = RobotLab.build(name: "summarizer", system_prompt: "Summarize concisely in one sentence.")
+
+robot.compress_history(
+  summarizer: ->(text) { summarizer.run("Summarize: #{text}").reply }
+)
+```
+
+**What is always preserved regardless of score:**
+- System messages
+- Tool call/result message pairs (dropping half would corrupt the conversation)
+- The most recent `recent_turns` user+assistant pairs
+
+Requires the `classifier` gem (`~> 2.3`):
+
+```ruby
+gem "classifier", "~> 2.3"
+```
+
+## Convergence Detection
+
+`RobotLab::Convergence` uses TF-IDF cosine similarity to detect when two independent agents have reached the same conclusion. The primary use case is a network router that skips an expensive reconciler robot when two verifiers already agree.
+
+```ruby
+# Check the similarity score directly (returns Float 0.0..1.0)
+score = RobotLab::Convergence.similarity(result_a.reply, result_b.reply)
+
+# Boolean convergence check (default threshold: 0.85)
+RobotLab::Convergence.detected?(result_a.reply, result_b.reply)
+
+# Custom threshold
+RobotLab::Convergence.detected?(text_a, text_b, threshold: 0.75)
+```
+
+Wire it into a network router for the reconciler fast-path:
+
+```ruby
+verifier_a = RobotLab.build(name: "verifier_a", system_prompt: "Verify the answer.")
+verifier_b = RobotLab.build(name: "verifier_b", system_prompt: "Independently verify the answer.")
+reconciler = RobotLab.build(name: "reconciler", system_prompt: "Reconcile conflicting answers.")
+
+router = lambda do |args|
+  a = args.context[:verifier_a]&.reply.to_s
+  b = args.context[:verifier_b]&.reply.to_s
+
+  # Skip reconciler when verifiers agree
+  RobotLab::Convergence.detected?(a, b) ? nil : ["reconciler"]
+end
+
+network = RobotLab.create_network(name: "verify", router: router) do
+  # ...
+end
+```
+
+Requires the `classifier` gem (`~> 2.3`).
+
+## Structured Delegation
+
+A robot can delegate a task to another robot using `delegate(to:, task:)`. The result is a `RobotResult` annotated with `delegated_by`, `duration`, and token counts.
+
+### Synchronous Delegation
+
+The default: blocks the calling robot until the delegatee finishes.
+
+```ruby
+analyst = RobotLab.build(name: "analyst", system_prompt: "Analyze data.")
+manager = RobotLab.build(name: "manager", system_prompt: "Coordinate work.")
+
+result = manager.delegate(to: analyst, task: "Summarize the Q3 report.")
+puts result.reply
+puts "Completed in %.2fs using %d tokens" % [result.duration, result.output_tokens]
+puts result.delegated_by  # => "manager"
+```
+
+### Asynchronous Delegation (Fan-out)
+
+Pass `async: true` to get a `DelegationFuture` back immediately. Call `.value` to block for the result when you need it.
+
+```ruby
+writer  = RobotLab.build(name: "writer",  system_prompt: "Write clearly.")
+analyst = RobotLab.build(name: "analyst", system_prompt: "Analyze data.")
+manager = RobotLab.build(name: "manager", system_prompt: "Coordinate.")
+
+# Fan out — both start immediately
+f1 = manager.delegate(to: analyst, task: "Analyze Q3 numbers", async: true)
+f2 = manager.delegate(to: writer,  task: "Draft the intro paragraph", async: true)
+
+# ... do other work here ...
+
+# Collect results (blocks if not yet done)
+analysis = f1.value
+draft    = f2.value
+
+# With a timeout (raises DelegationFuture::DelegationTimeout)
+result = f1.value(timeout: 30)
+```
+
+`DelegationFuture` API:
+
+| Method | Description |
+|--------|-------------|
+| `resolved?` | Non-blocking poll — true if completed or errored |
+| `value(timeout: nil)` | Block until done; re-raises any error from the delegatee |
+| `wait` | Alias for `value` |
+| `robot_name` | Name of the robot that was delegated to |
+| `delegated_by` | Name of the robot that created this future |
+
 ## Configuration
 
 RobotLab uses `MywayConfig` for configuration. Access the config object directly -- there is no `RobotLab.configure` block:

--- a/lib/robot_lab/version.rb
+++ b/lib/robot_lab/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RobotLab
-  VERSION = "0.0.11"
+  VERSION = "0.0.12"
 end


### PR DESCRIPTION
This commit introduces two new parallelism tracks built on top of Ruby's Ractor concurrency primitive:

1. **Ractor parallelism for CPU-bound tools**
   - Adds the `ractor_safe` class macro on `Tool` to opt a tool class into Ractor execution
   - Provides the `RactorWorkerPool` to manage a pool of Ractor workers, one per CPU core by default
   - Automatically routes `ractor_safe` tools through the worker pool, bypassing the GVL for CPU-intensive work
   - Introduces `RactorBoundary.freeze_deep` to deeply freeze objects for safe cross-Ractor sharing
   - Adds `ToolError` to propagate errors from the worker pool

2. **Ractor parallelism for robot pipelines**
   - Adds the `parallel_mode: :ractor` option to `Network.new` to use the `RactorNetworkScheduler`
   - The `RactorNetworkScheduler` dispatches independent tasks concurrently, waiting for dependency waves to complete
   - Introduces `RobotSpec` to encapsulate robot metadata in a frozen struct
   - Provides `RactorNetworkScheduler#run_pipeline` and `#run_spec` for executing parallel robot pipelines
   - Adds `RactorMemoryProxy` to allow safe cross-Ractor access to the `Memory` store

The commit also fixes an issue with the `ToolConfig::NONE_VALUES` constant, which was not Ractor-shareable due to its mutable inner array.

This work lays the foundation for significant performance improvements by leveraging Ractor's lightweight concurrency model, while introducing new APIs and patterns to make the parallelism features easy to use and integrate into existing Robot Lab projects.
