### PR TITLE
feat(durable): add cross-session robot learning via Durable::Learning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `Durable::Learning` — cross-session and within-session learning capability for robots. Robots accept `learn: true` and `learn_domain:` constructor params to persist knowledge across sessions via `~/.robot_lab/durable/` YAML files.
+- `Durable::Store` — YAML-backed knowledge store with file locking, keyword recall, and confidence tracking.
+- `Durable::Entry` — immutable value object for knowledge records with confidence progression.
+- `Durable::Reflector` — promotes session learnings to durable storage at end of each run.
+- `RecallKnowledge` tool — robots query past knowledge before uncertain decisions.
+- `RecordKnowledge` tool — robots persist new knowledge learned during a session.
+
 ## [0.1.0] - 2026-04-29
 
 ### Added

--- a/examples/32_newsletter_reader.rb
+++ b/examples/32_newsletter_reader.rb
@@ -1,0 +1,128 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Example 32: Newsletter Reader
+#
+# Downloads the latest RoboRuby (Ruby AI News) newsletter via RSS and uses
+# a robot to extract key stories, gems, and highlights from the issue.
+#
+# Demonstrates:
+#   - Custom tool that fetches live data from the web
+#   - Robot reasoning over real-world structured content
+#
+# Usage:
+#   ANTHROPIC_API_KEY=your_key ruby examples/32_newsletter_reader.rb
+
+require "net/http"
+require "open3"
+require "uri"
+require "rexml/document"
+require "rexml/xpath"
+
+ENV["ROBOT_LAB_TEMPLATE_PATH"] ||= File.join(__dir__, "prompts")
+
+require_relative "../lib/robot_lab"
+require "logger"
+
+RubyLLM.configure { |c| c.logger = Logger.new(File::NULL) }
+
+NEWSLETTER_RSS_URL = "https://rss.beehiiv.com/feeds/MTJunJRFxo.xml"
+
+class FetchLatestNewsletter < RubyLLM::Tool
+  description "Fetches the latest issue of the RoboRuby Ruby AI newsletter via RSS. " \
+              "Returns the issue title, publication date, web URL, and full article text."
+
+  def execute
+    uri      = URI(NEWSLETTER_RSS_URL)
+    response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.get(uri.request_uri) }
+
+    raise "HTTP #{response.code}: #{response.message}" unless response.is_a?(Net::HTTPSuccess)
+
+    doc  = REXML::Document.new(response.body)
+    item = REXML::XPath.first(doc, "//channel/item")
+    return "No issues found in the newsletter RSS feed." unless item
+
+    ns = { "content" => "http://purl.org/rss/1.0/modules/content/" }
+
+    title    = text_of(item, "title")
+    pub_date = text_of(item, "pubDate")
+    url      = text_of(item, "link")
+    html     = REXML::XPath.first(item, "content:encoded", ns)&.text ||
+               text_of(item, "description") || ""
+
+    plain = html_to_markdown(html)
+
+    <<~TEXT
+      Issue: #{title}
+      Published: #{pub_date}
+      URL: #{url}
+
+      #{plain[0, 20_000]}
+    TEXT
+  end
+
+  private
+
+  def text_of(node, xpath)
+    REXML::XPath.first(node, xpath)&.text&.strip
+  end
+
+  def html_to_markdown(html)
+    md, = Open3.capture3(
+      "html2markdown --domain=https://rubyai.beehiiv.com",
+      stdin_data: html
+    )
+    md.gsub(/\]\(([^)]+)\)/) { "](#{strip_utm($1)})" }
+  end
+
+  def strip_utm(url)
+    return url unless url.include?("?")
+    base, query = url.split("?", 2)
+    kept = query.split("&").reject { |p| p.start_with?("utm_") }
+    kept.empty? ? base : "#{base}?#{kept.join("&")}"
+  end
+end
+
+puts "=" * 60
+puts "Example 32: Newsletter Reader"
+puts "=" * 60
+puts
+
+robot = RobotLab.build(
+  name: "newsletter_analyst",
+  system_prompt: <<~PROMPT,
+    You are a sharp technical editor summarizing the RoboRuby Ruby AI newsletter
+    for busy developers. When given newsletter content, extract and present:
+
+    1. **Headline story** — the biggest news in Ruby/AI this issue.
+    2. **Notable gems or tools** — new or updated libraries worth knowing about.
+    3. **Key articles or tutorials** — important reads linked in the issue.
+    4. **Quick takes** — 3-5 bullets on other interesting items.
+
+    The content includes Markdown links in [text](url) format. You MUST preserve
+    these links in your output — every article title, gem name, and tool mentioned
+    should be a clickable Markdown link using the URL from the source content.
+
+    Use the FetchLatestNewsletter tool to get the content, then give your summary.
+    Be concise and opinionated — developers are busy.
+
+    Before deciding what to include, use the recall_knowledge tool to check past preferences.
+    After a discussion or decision reveals something worth remembering, use the record_knowledge tool.
+    When uncertain whether to include something and no past knowledge applies, skip it.
+  PROMPT
+  local_tools: [FetchLatestNewsletter],
+  model: "claude-haiku-4-5-20251001",
+  learn: true,
+  learn_domain: "newsletter curation"
+)
+
+puts "Fetching and summarizing the latest RoboRuby newsletter..."
+puts "-" * 60
+puts
+
+result = robot.run("Fetch the latest newsletter and give me your summary.")
+
+puts result.reply
+puts
+puts "-" * 60
+puts "Done."

--- a/lib/robot_lab/durable/entry.rb
+++ b/lib/robot_lab/durable/entry.rb
@@ -32,15 +32,16 @@ module RobotLab
 
       # Deserialize from a Hash (string or symbol keys).
       def self.from_h(hash)
+        h = hash.transform_keys(&:to_s)
         new(
-          content:    hash["content"]    || hash[:content],
-          reasoning:  hash["reasoning"]  || hash[:reasoning],
-          category:   (hash["category"] || hash[:category]).to_sym,
-          domain:     hash["domain"]     || hash[:domain],
-          confidence: (hash["confidence"] || hash[:confidence]).to_f,
-          use_count:  (hash["use_count"]  || hash[:use_count]).to_i,
-          created_at: hash["created_at"] || hash[:created_at],
-          updated_at: hash["updated_at"] || hash[:updated_at]
+          content:    h["content"],
+          reasoning:  h["reasoning"],
+          category:   h["category"]&.to_sym,
+          domain:     h["domain"],
+          confidence: h["confidence"].to_f,
+          use_count:  h["use_count"].to_i,
+          created_at: h["created_at"],
+          updated_at: h["updated_at"]
         )
       end
     end

--- a/lib/robot_lab/durable/entry.rb
+++ b/lib/robot_lab/durable/entry.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module RobotLab
+  module Durable
+    Entry = Data.define(:content, :reasoning, :category, :domain, :confidence, :use_count, :created_at, :updated_at) do
+      CONFIDENCE_INCREMENT = 0.1
+      MAX_CONFIDENCE       = 1.0
+
+      # Return a new Entry with confidence incremented and use_count bumped.
+      def confirm
+        new_confidence = [confidence + CONFIDENCE_INCREMENT, MAX_CONFIDENCE].min
+        with(
+          confidence: new_confidence.round(10),
+          use_count:  use_count + 1,
+          updated_at: Time.now.iso8601
+        )
+      end
+
+      # Serialize to a plain Hash with string keys (safe for YAML round-trip).
+      def to_h
+        {
+          "content"    => content,
+          "reasoning"  => reasoning,
+          "category"   => category.to_s,
+          "domain"     => domain,
+          "confidence" => confidence,
+          "use_count"  => use_count,
+          "created_at" => created_at,
+          "updated_at" => updated_at
+        }
+      end
+
+      # Deserialize from a Hash (string or symbol keys).
+      def self.from_h(hash)
+        new(
+          content:    hash["content"]    || hash[:content],
+          reasoning:  hash["reasoning"]  || hash[:reasoning],
+          category:   (hash["category"] || hash[:category]).to_sym,
+          domain:     hash["domain"]     || hash[:domain],
+          confidence: (hash["confidence"] || hash[:confidence]).to_f,
+          use_count:  (hash["use_count"]  || hash[:use_count]).to_i,
+          created_at: hash["created_at"] || hash[:created_at],
+          updated_at: hash["updated_at"] || hash[:updated_at]
+        )
+      end
+    end
+  end
+end

--- a/lib/robot_lab/durable/learning.rb
+++ b/lib/robot_lab/durable/learning.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module RobotLab
+  module Durable
+    module Learning
+      # Configure durable learning on a robot after initialization.
+      #
+      # @param domain [String] topic area for this robot's knowledge
+      # @param store_path [String, nil] override default ~/.robot_lab/durable path
+      def setup_durable_learning(domain:, store_path: nil)
+        @learn_domain  = domain.to_s
+        opts           = store_path ? { path: store_path } : {}
+        @durable_store = Store.new(**opts)
+
+        seed_from_store
+        @local_tools = (@local_tools + [RecallKnowledge, RecordKnowledge]).uniq
+      end
+
+      # Run the end-of-session reflection pass.
+      # Called automatically from Robot#run when durable learning is active.
+      def run_reflector
+        return unless @durable_store && @learn_domain && @learnings&.any?
+
+        Reflector.new(store: @durable_store, domain: @learn_domain).reflect(@learnings)
+      end
+
+      private
+
+      def seed_from_store
+        return unless @durable_store && @learn_domain
+
+        entries = @durable_store.recall(query: @learn_domain, domain: @learn_domain, min_confidence: 0.0)
+        entries.each do |e|
+          learn("[#{e.category}] #{e.content}: #{e.reasoning}")
+        end
+      end
+    end
+  end
+end

--- a/lib/robot_lab/durable/reflector.rb
+++ b/lib/robot_lab/durable/reflector.rb
@@ -13,12 +13,13 @@ module RobotLab
       #
       # @param learnings [Array<String>] robot.learnings from the completed session
       def reflect(learnings)
-        learnings.each do |text|
+        Array(learnings).each do |text|
           next if text.nil? || text.strip.empty?
 
           text = text.strip
           next if already_stored?(text)
 
+          now = Time.now.iso8601
           @store.record(
             Entry.new(
               content:    text,
@@ -27,8 +28,8 @@ module RobotLab
               domain:     @domain,
               confidence: 0.1,
               use_count:  0,
-              created_at: Time.now.iso8601,
-              updated_at: Time.now.iso8601
+              created_at: now,
+              updated_at: now
             )
           )
         end

--- a/lib/robot_lab/durable/reflector.rb
+++ b/lib/robot_lab/durable/reflector.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module RobotLab
+  module Durable
+    class Reflector
+      def initialize(store:, domain:)
+        @store  = store
+        @domain = domain.to_s
+      end
+
+      # Examine plain-text learnings accumulated during a session and promote
+      # any that are not already represented in the store.
+      #
+      # @param learnings [Array<String>] robot.learnings from the completed session
+      def reflect(learnings)
+        learnings.each do |text|
+          next if text.nil? || text.strip.empty?
+
+          text = text.strip
+          next if already_stored?(text)
+
+          @store.record(
+            Entry.new(
+              content:    text,
+              reasoning:  "Observed during session (auto-promoted by Reflector)",
+              category:   :pattern,
+              domain:     @domain,
+              confidence: 0.1,
+              use_count:  0,
+              created_at: Time.now.iso8601,
+              updated_at: Time.now.iso8601
+            )
+          )
+        end
+      end
+
+      private
+
+      def already_stored?(text)
+        @store.recall(query: text, domain: @domain, min_confidence: 0.0).any? do |e|
+          e.content.downcase == text.downcase
+        end
+      end
+    end
+  end
+end

--- a/lib/robot_lab/durable/store.rb
+++ b/lib/robot_lab/durable/store.rb
@@ -8,6 +8,8 @@ module RobotLab
     class Store
       DEFAULT_PATH = File.join(Dir.home, ".robot_lab", "durable")
 
+      MIN_WORD_LENGTH = 3
+
       def initialize(path: DEFAULT_PATH)
         @path = path
         FileUtils.mkdir_p(@path)
@@ -35,17 +37,19 @@ module RobotLab
       # @param entry [Entry]
       # @return [Entry] the stored entry (may differ if an existing one was updated)
       def record(entry)
-        entries = load_domain(entry.domain)
-        idx     = entries.find_index { |e| e.content.downcase == entry.content.downcase }
+        with_domain_lock(entry.domain) do
+          entries = load_domain(entry.domain)
+          idx     = entries.find_index { |e| e.content.downcase == entry.content.downcase }
 
-        if idx
-          entries[idx] = entries[idx].confirm
-        else
-          entries << entry
+          if idx
+            entries[idx] = entries[idx].confirm
+          else
+            entries << entry
+          end
+
+          save_domain(entry.domain, entries)
+          entries[idx || -1]
         end
-
-        save_domain(entry.domain, entries)
-        entries[idx || -1]
       end
 
       # Increment confidence and use_count on a stored entry.
@@ -66,20 +70,20 @@ module RobotLab
       end
 
       def tokenize(str)
-        str.downcase.split(/\s+/).reject { |w| w.length < 3 }
+        str.downcase.split(/\s+/).reject { |w| w.length < MIN_WORD_LENGTH }
       end
 
       def load_domain(domain)
         file = domain_file(domain)
         return [] unless File.exist?(file)
 
-        raw = YAML.safe_load(File.read(file)) || []
+        raw = Array(YAML.safe_load(File.read(file)) || [])
         raw.map { |h| Entry.from_h(h) }
       end
 
       def load_all
         Dir.glob(File.join(@path, "*.yaml")).flat_map do |file|
-          raw = YAML.safe_load(File.read(file)) || []
+          raw = Array(YAML.safe_load(File.read(file)) || [])
           raw.map { |h| Entry.from_h(h) }
         end
       end
@@ -90,15 +94,26 @@ module RobotLab
 
       # Replace a specific entry by exact content match (used by confirm).
       def record_exact(entry)
-        entries = load_domain(entry.domain)
-        idx     = entries.find_index { |e| e.content.downcase == entry.content.downcase }
-        entries[idx] = entry if idx
-        save_domain(entry.domain, entries)
+        with_domain_lock(entry.domain) do
+          entries = load_domain(entry.domain)
+          idx     = entries.find_index { |e| e.content.downcase == entry.content.downcase }
+          raise RobotLab::Error, "Cannot confirm: entry not found in domain '#{entry.domain}'" unless idx
+          entries[idx] = entry
+          save_domain(entry.domain, entries)
+        end
       end
 
       def domain_file(domain)
-        filename = domain.to_s.downcase.gsub(/\s+/, "_") + ".yaml"
-        File.join(@path, filename)
+        safe = domain.to_s.downcase.gsub(/[^a-z0-9]+/, "_").delete_prefix("_").delete_suffix("_")
+        File.join(@path, "#{safe}.yaml")
+      end
+
+      def with_domain_lock(domain, &block)
+        lock_path = domain_file(domain) + ".lock"
+        File.open(lock_path, File::RDWR | File::CREAT, 0o644) do |f|
+          f.flock(File::LOCK_EX)
+          block.call
+        end
       end
     end
   end

--- a/lib/robot_lab/durable/store.rb
+++ b/lib/robot_lab/durable/store.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "yaml"
+require "fileutils"
+
+module RobotLab
+  module Durable
+    class Store
+      DEFAULT_PATH = File.join(Dir.home, ".robot_lab", "durable")
+
+      def initialize(path: DEFAULT_PATH)
+        @path = path
+        FileUtils.mkdir_p(@path)
+      end
+
+      # Return entries matching query keywords, sorted by descending confidence.
+      #
+      # @param query [String] natural-language search string
+      # @param domain [String, nil] restrict to one domain file; nil searches all
+      # @param min_confidence [Float] exclude entries below this threshold
+      # @return [Array<Entry>]
+      def recall(query:, domain: nil, min_confidence: 0.0)
+        entries = domain ? load_domain(domain) : load_all
+        words   = tokenize(query)
+
+        entries
+          .select { |e| e.confidence >= min_confidence }
+          .select { |e| matches?(e, words) }
+          .sort_by { |e| -e.confidence }
+      end
+
+      # Persist a new entry. If an entry with the same content already exists
+      # in the domain file, increment its confidence and use_count instead.
+      #
+      # @param entry [Entry]
+      # @return [Entry] the stored entry (may differ if an existing one was updated)
+      def record(entry)
+        entries = load_domain(entry.domain)
+        idx     = entries.find_index { |e| e.content.downcase == entry.content.downcase }
+
+        if idx
+          entries[idx] = entries[idx].confirm
+        else
+          entries << entry
+        end
+
+        save_domain(entry.domain, entries)
+        entries[idx || -1]
+      end
+
+      # Increment confidence and use_count on a stored entry.
+      #
+      # @param entry [Entry]
+      # @return [Entry] the updated entry
+      def confirm(entry)
+        updated = entry.confirm
+        record_exact(updated)
+        updated
+      end
+
+      private
+
+      def matches?(entry, words)
+        text = "#{entry.content} #{entry.domain}".downcase
+        words.any? { |w| text.include?(w) }
+      end
+
+      def tokenize(str)
+        str.downcase.split(/\s+/).reject { |w| w.length < 3 }
+      end
+
+      def load_domain(domain)
+        file = domain_file(domain)
+        return [] unless File.exist?(file)
+
+        raw = YAML.safe_load(File.read(file)) || []
+        raw.map { |h| Entry.from_h(h) }
+      end
+
+      def load_all
+        Dir.glob(File.join(@path, "*.yaml")).flat_map do |file|
+          raw = YAML.safe_load(File.read(file)) || []
+          raw.map { |h| Entry.from_h(h) }
+        end
+      end
+
+      def save_domain(domain, entries)
+        File.write(domain_file(domain), YAML.dump(entries.map(&:to_h)))
+      end
+
+      # Replace a specific entry by exact content match (used by confirm).
+      def record_exact(entry)
+        entries = load_domain(entry.domain)
+        idx     = entries.find_index { |e| e.content.downcase == entry.content.downcase }
+        entries[idx] = entry if idx
+        save_domain(entry.domain, entries)
+      end
+
+      def domain_file(domain)
+        filename = domain.to_s.downcase.gsub(/\s+/, "_") + ".yaml"
+        File.join(@path, filename)
+      end
+    end
+  end
+end

--- a/lib/robot_lab/recall_knowledge.rb
+++ b/lib/robot_lab/recall_knowledge.rb
@@ -19,8 +19,6 @@ module RobotLab
       if entries.empty?
         "No relevant past knowledge found for: #{query}. When in doubt, skip."
       else
-        entries.each { |e| store.confirm(e) }
-
         lines = entries.map do |e|
           "[#{e.category}/conf:#{format("%.1f", e.confidence)}] #{e.content} — #{e.reasoning}"
         end

--- a/lib/robot_lab/recall_knowledge.rb
+++ b/lib/robot_lab/recall_knowledge.rb
@@ -11,7 +11,7 @@ module RobotLab
     param :domain, type: "string", desc: "Topic area to search (e.g. 'newsletter curation')", required: false
 
     def execute(query:, domain: nil)
-      store = robot&.instance_variable_get(:@durable_store)
+      store = robot&.durable_store
       return "No durable store configured on this robot." unless store
 
       entries = store.recall(query: query, domain: domain, min_confidence: 0.0)

--- a/lib/robot_lab/recall_knowledge.rb
+++ b/lib/robot_lab/recall_knowledge.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module RobotLab
+  class RecallKnowledge < Tool
+    description "Recall relevant knowledge from past sessions before making a decision. " \
+                "Use this when uncertain whether to include or skip content, or when you want " \
+                "to check if you have seen a similar situation before. " \
+                "When in doubt and no relevant knowledge is found, skip the action."
+
+    param :query,  type: "string", desc: "Natural language description of the decision you are about to make"
+    param :domain, type: "string", desc: "Topic area to search (e.g. 'newsletter curation')", required: false
+
+    def execute(query:, domain: nil)
+      store = robot&.instance_variable_get(:@durable_store)
+      return "No durable store configured on this robot." unless store
+
+      entries = store.recall(query: query, domain: domain, min_confidence: 0.0)
+
+      if entries.empty?
+        "No relevant past knowledge found for: #{query}. When in doubt, skip."
+      else
+        entries.each { |e| store.confirm(e) }
+
+        lines = entries.map do |e|
+          "[#{e.category}/conf:#{format("%.1f", e.confidence)}] #{e.content} — #{e.reasoning}"
+        end
+
+        "Relevant past knowledge:\n#{lines.join("\n")}"
+      end
+    end
+  end
+end

--- a/lib/robot_lab/record_knowledge.rb
+++ b/lib/robot_lab/record_knowledge.rb
@@ -27,9 +27,10 @@ module RobotLab
     param :domain,    type: "string", desc: "Topic area this applies to (e.g. 'newsletter curation', 'ruby tooling')"
 
     def execute(content:, reasoning:, category:, domain:)
-      store = robot&.instance_variable_get(:@durable_store)
+      store = robot&.durable_store
       return "No durable store configured on this robot." unless store
 
+      now = Time.now.iso8601
       entry = Durable::Entry.new(
         content:,
         reasoning:,
@@ -37,8 +38,8 @@ module RobotLab
         domain:,
         confidence: 0.1,
         use_count:  0,
-        created_at: Time.now.iso8601,
-        updated_at: Time.now.iso8601
+        created_at: now,
+        updated_at: now
       )
 
       store.record(entry)

--- a/lib/robot_lab/record_knowledge.rb
+++ b/lib/robot_lab/record_knowledge.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module RobotLab
+  # Tool that lets a robot record a piece of knowledge learned during a session.
+  #
+  # Use after a decision or discussion reveals something worth remembering:
+  # a user preference, a reliable pattern, or a factual insight. Recorded
+  # knowledge persists across future sessions via the robot's durable store.
+  #
+  # @example
+  #   # LLM calls: record_knowledge(
+  #   #   content: "User prefers concise responses",
+  #   #   reasoning: "User asked for shorter answers twice",
+  #   #   category: "preference",
+  #   #   domain: "communication style"
+  #   # )
+  #
+  class RecordKnowledge < Tool
+    description "Record a piece of knowledge learned during this session. " \
+                "Use after a decision or discussion reveals something worth remembering: " \
+                "a user preference, a reliable pattern, or a factual insight. " \
+                "Recorded knowledge persists across future sessions."
+
+    param :content,   type: "string", desc: "The knowledge to record, in plain language (one clear statement)"
+    param :reasoning, type: "string", desc: "Why this is worth remembering — the observation or discussion that led to it"
+    param :category,  type: "string", desc: "One of: fact, preference, pattern, correction"
+    param :domain,    type: "string", desc: "Topic area this applies to (e.g. 'newsletter curation', 'ruby tooling')"
+
+    def execute(content:, reasoning:, category:, domain:)
+      store = robot&.instance_variable_get(:@durable_store)
+      return "No durable store configured on this robot." unless store
+
+      entry = Durable::Entry.new(
+        content:,
+        reasoning:,
+        category:   category.to_sym,
+        domain:,
+        confidence: 0.1,
+        use_count:  0,
+        created_at: Time.now.iso8601,
+        updated_at: Time.now.iso8601
+      )
+
+      store.record(entry)
+      robot.learn("#{content} (#{domain})")
+
+      "Recorded: #{content}"
+    end
+  end
+end

--- a/lib/robot_lab/robot.rb
+++ b/lib/robot_lab/robot.rb
@@ -206,8 +206,12 @@ module RobotLab
       persisted = @memory.get(:learnings)
       @learnings = Array(persisted) if persisted
 
-      if learn && learn_domain
-        setup_durable_learning(domain: learn_domain, store_path: store_path)
+      if learn
+        if learn_domain
+          setup_durable_learning(domain: learn_domain, store_path: store_path)
+        else
+          warn "[RobotLab] Robot '#{@name}': learn: true requires learn_domain: to be set. Durable learning disabled."
+        end
       end
 
       # Ensure config is loaded (triggers PM setup, RubyLLM config, etc.)

--- a/lib/robot_lab/robot.rb
+++ b/lib/robot_lab/robot.rb
@@ -69,7 +69,8 @@ module RobotLab
     attr_reader :name, :description, :template, :system_prompt,
                 :local_tools, :mcp_clients, :mcp_tools, :memory,
                 :bus, :outbox, :config, :skills, :provider,
-                :total_input_tokens, :total_output_tokens, :learnings
+                :total_input_tokens, :total_output_tokens, :learnings,
+                :durable_store, :learn_domain
 
     # @!attribute [r] mcp_config
     #   @return [Symbol, Array] build-time MCP configuration (raw, unresolved)

--- a/lib/robot_lab/robot.rb
+++ b/lib/robot_lab/robot.rb
@@ -43,6 +43,7 @@ module RobotLab
     include Robot::MCPManagement
     include Robot::BusMessaging
     include Robot::HistorySearch
+    include Durable::Learning
 
     # @!attribute [r] name
     #   @return [String] the unique identifier for the robot
@@ -132,7 +133,10 @@ module RobotLab
       max_tool_rounds: nil,
       token_budget: nil,
       mcp_discovery: false,
-      config: nil
+      config: nil,
+      learn: false,
+      learn_domain: nil,
+      store_path: nil
     )
       @name = name.to_s
       @name_from_constructor = (name.to_s != "robot")
@@ -201,6 +205,10 @@ module RobotLab
       # Restore persisted learnings from inherent memory if present
       persisted = @memory.get(:learnings)
       @learnings = Array(persisted) if persisted
+
+      if learn && learn_domain
+        setup_durable_learning(domain: learn_domain, store_path: store_path)
+      end
 
       # Ensure config is loaded (triggers PM setup, RubyLLM config, etc.)
       config = RobotLab.config
@@ -365,6 +373,7 @@ module RobotLab
         result
       ensure
         restore_tool_call_callback if @config.max_tool_rounds
+        run_reflector if @durable_store
         run_memory.current_writer = previous_writer
       end
     end

--- a/test/robot_lab/durable/entry_test.rb
+++ b/test/robot_lab/durable/entry_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RobotLab::Durable::EntryTest < Minitest::Test
+  def build_entry(overrides = {})
+    RobotLab::Durable::Entry.new(
+      content:    overrides.fetch(:content,    "Skip LangChain content"),
+      reasoning:  overrides.fetch(:reasoning,  "User is Ruby-only"),
+      category:   overrides.fetch(:category,   :preference),
+      domain:     overrides.fetch(:domain,     "newsletter curation"),
+      confidence: overrides.fetch(:confidence, 0.1),
+      use_count:  overrides.fetch(:use_count,  0),
+      created_at: overrides.fetch(:created_at, "2026-05-06T12:00:00Z"),
+      updated_at: overrides.fetch(:updated_at, "2026-05-06T12:00:00Z")
+    )
+  end
+
+  def test_entry_is_immutable
+    entry = build_entry
+    assert_raises(NoMethodError) { entry.content = "changed" }
+  end
+
+  def test_confirm_increments_confidence_by_0_1
+    entry = build_entry(confidence: 0.2, use_count: 1)
+    confirmed = entry.confirm
+    assert_in_delta 0.3, confirmed.confidence, 0.001
+  end
+
+  def test_confirm_increments_use_count
+    entry = build_entry(use_count: 3)
+    confirmed = entry.confirm
+    assert_equal 4, confirmed.use_count
+  end
+
+  def test_confirm_does_not_exceed_max_confidence
+    entry = build_entry(confidence: 0.95)
+    confirmed = entry.confirm
+    assert_in_delta 1.0, confirmed.confidence, 0.001
+    confirmed2 = confirmed.confirm
+    assert_in_delta 1.0, confirmed2.confidence, 0.001
+  end
+
+  def test_confirm_returns_new_entry_leaves_original_unchanged
+    entry = build_entry(confidence: 0.1)
+    entry.confirm
+    assert_in_delta 0.1, entry.confidence, 0.001
+  end
+
+  def test_to_h_returns_string_keys
+    entry = build_entry
+    h = entry.to_h
+    assert_equal "Skip LangChain content", h["content"]
+    assert_equal "preference",             h["category"]
+    assert_in_delta 0.1,                   h["confidence"], 0.001
+  end
+
+  def test_from_h_with_string_keys
+    h = {
+      "content"    => "Skip LangChain content",
+      "reasoning"  => "User is Ruby-only",
+      "category"   => "preference",
+      "domain"     => "newsletter curation",
+      "confidence" => 0.2,
+      "use_count"  => 1,
+      "created_at" => "2026-05-06T12:00:00Z",
+      "updated_at" => "2026-05-06T12:00:00Z"
+    }
+    entry = RobotLab::Durable::Entry.from_h(h)
+    assert_equal "Skip LangChain content", entry.content
+    assert_equal :preference,              entry.category
+    assert_in_delta 0.2,                   entry.confidence, 0.001
+  end
+
+  def test_from_h_roundtrips_through_to_h
+    original = build_entry(confidence: 0.4, use_count: 2)
+    roundtripped = RobotLab::Durable::Entry.from_h(original.to_h)
+    assert_equal original.content,    roundtripped.content
+    assert_equal original.reasoning,  roundtripped.reasoning
+    assert_equal original.category,   roundtripped.category
+    assert_in_delta original.confidence, roundtripped.confidence, 0.001
+    assert_equal original.use_count,  roundtripped.use_count
+  end
+end

--- a/test/robot_lab/durable/entry_test.rb
+++ b/test/robot_lab/durable/entry_test.rb
@@ -119,4 +119,13 @@ class RobotLab::Durable::EntryTest < Minitest::Test
     assert_kind_of Integer, entry.use_count
     assert_equal 3, entry.use_count
   end
+
+  def test_from_h_with_mixed_key_types_normalizes_correctly
+    h = { "content" => "fact", reasoning: "why", "category" => "fact",
+          domain: "test", "confidence" => 0.5, use_count: 1,
+          "created_at" => "2026-05-06T12:00:00Z", "updated_at" => "2026-05-06T12:00:00Z" }
+    entry = RobotLab::Durable::Entry.from_h(h)
+    assert_equal "fact", entry.content
+    assert_equal "why",  entry.reasoning
+  end
 end

--- a/test/robot_lab/durable/entry_test.rb
+++ b/test/robot_lab/durable/entry_test.rb
@@ -81,4 +81,42 @@ class RobotLab::Durable::EntryTest < Minitest::Test
     assert_in_delta original.confidence, roundtripped.confidence, 0.001
     assert_equal original.use_count,  roundtripped.use_count
   end
+
+  def test_from_h_with_symbol_keys
+    h = {
+      content:    "Skip LangChain content",
+      reasoning:  "User is Ruby-only",
+      category:   "preference",
+      domain:     "newsletter curation",
+      confidence: 0.3,
+      use_count:  1,
+      created_at: "2026-05-06T12:00:00Z",
+      updated_at: "2026-05-06T12:00:00Z"
+    }
+    entry = RobotLab::Durable::Entry.from_h(h)
+    assert_equal "Skip LangChain content", entry.content
+    assert_equal :preference,              entry.category
+  end
+
+  def test_confirm_refreshes_updated_at
+    entry = build_entry(updated_at: "2020-01-01T00:00:00Z")
+    confirmed = entry.confirm
+    refute_equal "2020-01-01T00:00:00Z", confirmed.updated_at
+  end
+
+  def test_from_h_deserializes_use_count_as_integer
+    h = {
+      "content"    => "fact",
+      "reasoning"  => "reason",
+      "category"   => "fact",
+      "domain"     => "test",
+      "confidence" => 0.1,
+      "use_count"  => "3",
+      "created_at" => "2026-05-06T12:00:00Z",
+      "updated_at" => "2026-05-06T12:00:00Z"
+    }
+    entry = RobotLab::Durable::Entry.from_h(h)
+    assert_kind_of Integer, entry.use_count
+    assert_equal 3, entry.use_count
+  end
 end

--- a/test/robot_lab/durable/reflector_test.rb
+++ b/test/robot_lab/durable/reflector_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+class RobotLab::Durable::ReflectorTest < Minitest::Test
+  def setup
+    @tmpdir    = Dir.mktmpdir("robot_lab_reflector_test")
+    @store     = RobotLab::Durable::Store.new(path: @tmpdir)
+    @reflector = RobotLab::Durable::Reflector.new(store: @store, domain: "newsletter curation")
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmpdir)
+  end
+
+  def test_promotes_new_learning_to_store
+    @reflector.reflect(["User prefers practical tooling examples"])
+    results = @store.recall(query: "practical tooling", domain: "newsletter curation")
+    assert_equal 1, results.size
+    assert_equal "User prefers practical tooling examples", results.first.content
+  end
+
+  def test_does_not_duplicate_existing_entry
+    @store.record(
+      RobotLab::Durable::Entry.new(
+        content:    "User prefers practical tooling examples",
+        reasoning:  "already stored",
+        category:   :pattern,
+        domain:     "newsletter curation",
+        confidence: 0.3,
+        use_count:  2,
+        created_at: "2026-05-06T12:00:00Z",
+        updated_at: "2026-05-06T12:00:00Z"
+      )
+    )
+    @reflector.reflect(["User prefers practical tooling examples"])
+    results = @store.recall(query: "practical tooling", domain: "newsletter curation")
+    assert_equal 1, results.size
+  end
+
+  def test_promotes_multiple_learnings
+    @reflector.reflect(["First observation", "Second observation"])
+    r1 = @store.recall(query: "first",  domain: "newsletter curation")
+    r2 = @store.recall(query: "second", domain: "newsletter curation")
+    assert_equal 1, r1.size
+    assert_equal 1, r2.size
+  end
+
+  def test_skips_nil_and_empty_learnings
+    @reflector.reflect(["", "  ", nil].compact)
+    results = @store.recall(query: "newsletter curation", domain: "newsletter curation")
+    assert_empty results
+  end
+
+  def test_new_entries_start_with_low_confidence
+    @reflector.reflect(["Something worth knowing"])
+    results = @store.recall(query: "worth knowing", domain: "newsletter curation")
+    assert_in_delta 0.1, results.first.confidence, 0.001
+  end
+
+  def test_existing_entry_confidence_not_overwritten_by_reflect
+    @store.record(
+      RobotLab::Durable::Entry.new(
+        content:    "High confidence pattern",
+        reasoning:  "well established",
+        category:   :pattern,
+        domain:     "newsletter curation",
+        confidence: 0.8,
+        use_count:  7,
+        created_at: "2026-05-06T12:00:00Z",
+        updated_at: "2026-05-06T12:00:00Z"
+      )
+    )
+    @reflector.reflect(["High confidence pattern"])
+    results = @store.recall(query: "High confidence pattern", domain: "newsletter curation")
+    # Should not reset to 0.1 — already_stored? guard prevents re-recording
+    assert_in_delta 0.8, results.first.confidence, 0.001
+  end
+end

--- a/test/robot_lab/durable/reflector_test.rb
+++ b/test/robot_lab/durable/reflector_test.rb
@@ -48,7 +48,7 @@ class RobotLab::Durable::ReflectorTest < Minitest::Test
   end
 
   def test_skips_nil_and_empty_learnings
-    @reflector.reflect(["", "  ", nil].compact)
+    @reflector.reflect([nil, "", "  "])
     results = @store.recall(query: "newsletter curation", domain: "newsletter curation")
     assert_empty results
   end

--- a/test/robot_lab/durable/store_test.rb
+++ b/test/robot_lab/durable/store_test.rb
@@ -105,4 +105,9 @@ class RobotLab::Durable::StoreTest < Minitest::Test
     @store.record(build_entry(domain: "newsletter curation"))
     assert File.exist?(File.join(@tmpdir, "newsletter_curation.yaml"))
   end
+
+  def test_confirm_raises_when_entry_not_in_store
+    entry = build_entry(content: "Not stored anywhere")
+    assert_raises(RobotLab::Error) { @store.confirm(entry) }
+  end
 end

--- a/test/robot_lab/durable/store_test.rb
+++ b/test/robot_lab/durable/store_test.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+class RobotLab::Durable::StoreTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir("robot_lab_durable_test")
+    @store  = RobotLab::Durable::Store.new(path: @tmpdir)
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmpdir)
+  end
+
+  def build_entry(overrides = {})
+    RobotLab::Durable::Entry.new(
+      content:    overrides.fetch(:content,    "Skip LangChain content"),
+      reasoning:  overrides.fetch(:reasoning,  "User is Ruby-only"),
+      category:   overrides.fetch(:category,   :preference),
+      domain:     overrides.fetch(:domain,     "newsletter curation"),
+      confidence: overrides.fetch(:confidence, 0.1),
+      use_count:  overrides.fetch(:use_count,  0),
+      created_at: "2026-05-06T12:00:00Z",
+      updated_at: "2026-05-06T12:00:00Z"
+    )
+  end
+
+  def test_record_persists_entry_to_disk
+    entry = build_entry
+    @store.record(entry)
+    file = File.join(@tmpdir, "newsletter_curation.yaml")
+    assert File.exist?(file)
+  end
+
+  def test_record_appends_new_entry
+    @store.record(build_entry(content: "First"))
+    @store.record(build_entry(content: "Second"))
+    entries = @store.recall(query: "newsletter", domain: "newsletter curation")
+    assert_equal 2, entries.size
+  end
+
+  def test_record_updates_existing_entry_by_content_match
+    @store.record(build_entry(content: "Skip LangChain content", confidence: 0.1))
+    @store.record(build_entry(content: "Skip LangChain content", confidence: 0.1))
+    entries = @store.recall(query: "LangChain", domain: "newsletter curation")
+    assert_equal 1, entries.size
+  end
+
+  def test_record_increments_confidence_on_duplicate
+    @store.record(build_entry(content: "Skip LangChain content", confidence: 0.1))
+    @store.record(build_entry(content: "Skip LangChain content", confidence: 0.1))
+    entries = @store.recall(query: "LangChain", domain: "newsletter curation")
+    assert_in_delta 0.2, entries.first.confidence, 0.001
+  end
+
+  def test_recall_returns_empty_array_when_no_entries
+    results = @store.recall(query: "anything", domain: "newsletter curation")
+    assert_empty results
+  end
+
+  def test_recall_matches_on_content_keyword
+    @store.record(build_entry(content: "Skip LangChain tutorials"))
+    results = @store.recall(query: "LangChain", domain: "newsletter curation")
+    assert_equal 1, results.size
+    assert_equal "Skip LangChain tutorials", results.first.content
+  end
+
+  def test_recall_is_case_insensitive
+    @store.record(build_entry(content: "Skip langchain tutorials"))
+    results = @store.recall(query: "LangChain", domain: "newsletter curation")
+    assert_equal 1, results.size
+  end
+
+  def test_recall_filters_by_min_confidence
+    @store.record(build_entry(content: "Low confidence entry",  confidence: 0.1))
+    @store.record(build_entry(content: "High confidence entry", confidence: 0.8))
+    results = @store.recall(query: "confidence entry", domain: "newsletter curation", min_confidence: 0.5)
+    assert_equal 1, results.size
+    assert_equal "High confidence entry", results.first.content
+  end
+
+  def test_recall_sorts_by_descending_confidence
+    @store.record(build_entry(content: "Low entry",  confidence: 0.2))
+    @store.record(build_entry(content: "High entry", confidence: 0.8))
+    results = @store.recall(query: "entry", domain: "newsletter curation")
+    assert_equal "High entry", results.first.content
+  end
+
+  def test_recall_without_domain_searches_all_domains
+    @store.record(build_entry(domain: "newsletter curation", content: "Newsletter fact"))
+    @store.record(build_entry(domain: "ruby tooling",        content: "Tooling fact"))
+    results = @store.recall(query: "fact")
+    assert_equal 2, results.size
+  end
+
+  def test_confirm_increments_confidence_on_disk
+    entry = @store.record(build_entry(confidence: 0.2))
+    @store.confirm(entry)
+    results = @store.recall(query: "LangChain", domain: "newsletter curation")
+    assert_in_delta 0.3, results.first.confidence, 0.001
+  end
+
+  def test_spaces_in_domain_become_underscores_in_filename
+    @store.record(build_entry(domain: "newsletter curation"))
+    assert File.exist?(File.join(@tmpdir, "newsletter_curation.yaml"))
+  end
+end

--- a/test/robot_lab/recall_knowledge_test.rb
+++ b/test/robot_lab/recall_knowledge_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+class RobotLab::RecallKnowledgeTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir("robot_lab_recall_test")
+    @store  = RobotLab::Durable::Store.new(path: @tmpdir)
+    @robot  = build_robot(name: "test_bot")
+    @robot.instance_variable_set(:@durable_store, @store)
+    @tool   = RobotLab::RecallKnowledge.new(robot: @robot)
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmpdir)
+  end
+
+  def seed_entry(content:, confidence: 0.5, domain: "newsletter curation")
+    @store.record(
+      RobotLab::Durable::Entry.new(
+        content:,
+        reasoning:  "seeded in test",
+        category:   :preference,
+        domain:,
+        confidence:,
+        use_count:  0,
+        created_at: "2026-05-06T12:00:00Z",
+        updated_at: "2026-05-06T12:00:00Z"
+      )
+    )
+  end
+
+  def test_returns_matching_entries_as_formatted_string
+    seed_entry(content: "Skip LangChain tutorials")
+    result = @tool.execute(query: "LangChain", domain: "newsletter curation")
+    assert_match(/Skip LangChain tutorials/, result)
+    assert_match(/Relevant past knowledge/, result)
+  end
+
+  def test_returns_no_match_message_when_empty
+    result = @tool.execute(query: "LangChain", domain: "newsletter curation")
+    assert_match(/No relevant past knowledge/, result)
+  end
+
+  def test_no_match_message_includes_skip_guidance
+    result = @tool.execute(query: "something unknown", domain: "newsletter curation")
+    assert_match(/skip/, result.downcase)
+  end
+
+  def test_increments_confidence_on_recall
+    seed_entry(content: "Skip LangChain tutorials", confidence: 0.3)
+    @tool.execute(query: "LangChain", domain: "newsletter curation")
+    results = @store.recall(query: "LangChain", domain: "newsletter curation")
+    assert_in_delta 0.4, results.first.confidence, 0.001
+  end
+
+  def test_returns_error_when_no_store_configured
+    @robot.instance_variable_set(:@durable_store, nil)
+    result = @tool.execute(query: "anything")
+    assert_match(/No durable store/, result)
+  end
+
+  def test_includes_category_and_confidence_in_output
+    seed_entry(content: "Include RubyLLM updates", confidence: 0.6)
+    result = @tool.execute(query: "RubyLLM", domain: "newsletter curation")
+    assert_match(/preference/, result)
+    assert_match(/0\./, result)
+  end
+end

--- a/test/robot_lab/recall_knowledge_test.rb
+++ b/test/robot_lab/recall_knowledge_test.rb
@@ -48,11 +48,11 @@ class RobotLab::RecallKnowledgeTest < Minitest::Test
     assert_match(/skip/, result.downcase)
   end
 
-  def test_increments_confidence_on_recall
+  def test_does_not_change_confidence_on_recall
     seed_entry(content: "Skip LangChain tutorials", confidence: 0.3)
     @tool.execute(query: "LangChain", domain: "newsletter curation")
     results = @store.recall(query: "LangChain", domain: "newsletter curation")
-    assert_in_delta 0.4, results.first.confidence, 0.001
+    assert_in_delta 0.3, results.first.confidence, 0.001
   end
 
   def test_returns_error_when_no_store_configured

--- a/test/robot_lab/record_knowledge_test.rb
+++ b/test/robot_lab/record_knowledge_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+class RobotLab::RecordKnowledgeTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir("robot_lab_record_test")
+    @store  = RobotLab::Durable::Store.new(path: @tmpdir)
+    @robot  = build_robot(name: "test_bot")
+    @robot.instance_variable_set(:@durable_store, @store)
+    @tool   = RobotLab::RecordKnowledge.new(robot: @robot)
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmpdir)
+  end
+
+  def test_records_entry_to_store
+    @tool.execute(
+      content:   "Skip Python-only tools",
+      reasoning: "User works exclusively in Ruby",
+      category:  "preference",
+      domain:    "newsletter curation"
+    )
+    results = @store.recall(query: "Python", domain: "newsletter curation")
+    assert_equal 1, results.size
+    assert_equal "Skip Python-only tools", results.first.content
+  end
+
+  def test_returns_confirmation_string
+    result = @tool.execute(
+      content:   "Prefer gems with low dependency count",
+      reasoning: "User values minimal dependency footprint",
+      category:  "preference",
+      domain:    "newsletter curation"
+    )
+    assert_match(/Recorded/, result)
+    assert_match(/dependency/, result)
+  end
+
+  def test_adds_learning_to_robot
+    @tool.execute(
+      content:   "Include RubyLLM news",
+      reasoning: "User maintains RubyLLM integrations",
+      category:  "preference",
+      domain:    "newsletter curation"
+    )
+    assert @robot.learnings.any? { |l| l.include?("RubyLLM") }
+  end
+
+  def test_returns_error_when_no_store_configured
+    @robot.instance_variable_set(:@durable_store, nil)
+    result = @tool.execute(
+      content: "anything", reasoning: "any", category: "fact", domain: "test"
+    )
+    assert_match(/No durable store/, result)
+  end
+
+  def test_entry_starts_with_low_confidence
+    @tool.execute(
+      content:   "New pattern",
+      reasoning: "Observed once",
+      category:  "pattern",
+      domain:    "newsletter curation"
+    )
+    results = @store.recall(query: "New pattern", domain: "newsletter curation")
+    assert_in_delta 0.1, results.first.confidence, 0.001
+  end
+end

--- a/test/robot_lab/robot/durable_learning_test.rb
+++ b/test/robot_lab/robot/durable_learning_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+class RobotLab::Robot::DurableLearningTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir("robot_lab_robot_durable_test")
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmpdir)
+  end
+
+  def test_learn_false_does_not_set_durable_store
+    robot = RobotLab::Robot.new(name: "no_learn", template: :assistant)
+    assert_nil robot.durable_store
+  end
+
+  def test_learn_true_sets_durable_store
+    robot = RobotLab::Robot.new(
+      name:         "learner",
+      template:     :assistant,
+      learn:        true,
+      learn_domain: "test domain",
+      store_path:   @tmpdir
+    )
+    refute_nil robot.durable_store
+  end
+
+  def test_learn_true_adds_recall_and_record_tools
+    robot = RobotLab::Robot.new(
+      name:         "learner",
+      template:     :assistant,
+      learn:        true,
+      learn_domain: "test domain",
+      store_path:   @tmpdir
+    )
+    tool_classes = robot.local_tools.map { |t| t.is_a?(Class) ? t : t.class }
+    assert_includes tool_classes, RobotLab::RecallKnowledge
+    assert_includes tool_classes, RobotLab::RecordKnowledge
+  end
+
+  def test_learn_domain_readable
+    robot = RobotLab::Robot.new(
+      name:         "learner",
+      template:     :assistant,
+      learn:        true,
+      learn_domain: "newsletter curation",
+      store_path:   @tmpdir
+    )
+    assert_equal "newsletter curation", robot.learn_domain
+  end
+
+  def test_learn_true_seeds_learnings_from_existing_store
+    store = RobotLab::Durable::Store.new(path: @tmpdir)
+    store.record(
+      RobotLab::Durable::Entry.new(
+        content:    "Skip Python-only tools",
+        reasoning:  "Ruby-only context",
+        category:   :preference,
+        domain:     "test domain",
+        confidence: 0.5,
+        use_count:  2,
+        created_at: "2026-05-06T12:00:00Z",
+        updated_at: "2026-05-06T12:00:00Z"
+      )
+    )
+
+    robot = RobotLab::Robot.new(
+      name:         "learner",
+      template:     :assistant,
+      learn:        true,
+      learn_domain: "test domain",
+      store_path:   @tmpdir
+    )
+
+    assert robot.learnings.any? { |l| l.include?("Skip Python-only tools") }
+  end
+
+  def test_learn_false_adds_no_extra_tools
+    robot = RobotLab::Robot.new(name: "no_learn", template: :assistant)
+    tool_classes = robot.local_tools.map { |t| t.is_a?(Class) ? t : t.class }
+    refute_includes tool_classes, RobotLab::RecallKnowledge
+    refute_includes tool_classes, RobotLab::RecordKnowledge
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Durable::Learning` — an opt-in mixin that gives any robot persistent, cross-session knowledge. Enable with `learn: true, learn_domain: "your domain"` on `RobotLab.build`.
- Knowledge is stored as structured YAML in `~/.robot_lab/durable/` (one file per domain) with confidence scores that rise as patterns are confirmed by repeated use.
- Two new tools (`RecallKnowledge`, `RecordKnowledge`) let the robot query and record knowledge during a session. A `Durable::Reflector` automatically promotes session learnings to disk at the end of each run.
- Updates `examples/32_newsletter_reader.rb` as the motivating example — the newsletter robot now learns curation preferences over time.

## New files

| File | Purpose |
|------|---------|
| `lib/robot_lab/durable/entry.rb` | Immutable `Entry` value object with confidence tracking |
| `lib/robot_lab/durable/store.rb` | YAML persistence with file locking and keyword recall |
| `lib/robot_lab/durable/reflector.rb` | Promotes session learnings to store at run end |
| `lib/robot_lab/durable/learning.rb` | Mixin wired into `Robot` |
| `lib/robot_lab/recall_knowledge.rb` | Tool: query past knowledge before deciding |
| `lib/robot_lab/record_knowledge.rb` | Tool: persist new knowledge during a session |

## Test plan

- [ ] `bundle exec rake test` — 1194 runs, 0 failures
- [ ] `RobotLab.build(name: "bot", learn: true, learn_domain: "test")` — verify `durable_store` is set
- [ ] `RobotLab.build(name: "bot", learn: true)` — verify warning is emitted for missing `learn_domain`
- [ ] Run `examples/32_newsletter_reader.rb` — verify robot fetches newsletter and tools are available
- [ ] Check `~/.robot_lab/durable/` after a run — verify YAML domain files are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)